### PR TITLE
[Feat/i35] 메인페이지 무한스크롤, 애니메이션 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
     "dayjs": "^1.11.3",
+    "framer-motion": "^7.0.0",
     "loadash": "^1.0.0",
     "lodash": "^4.17.21",
     "node-sass": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "node-sass": "^7.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-intersection-observer": "^9.4.0",
     "react-query": "^3.39.1",
     "react-quill": "^1.3.5",
     "react-responsive": "^9.0.0-beta.10",

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -25,7 +25,8 @@ api.interceptors.request.use((config: any) => {
 // https://api.totee.link/swagger-ui.html#/
 
 export const PostAPI = {
-  getPostList: () => api.get(`/api/v1/post/list`),
+  getPostList: (page = 0, size = 5) =>
+    api.get(`/api/v1/post/list?page=${page}&size=${size}`),
   getPostByPostId: (postId: number) => api.get(`/api/v1/post/${postId}`),
   searchPostList: (title: string) => api.get(`/api/v1/post/search/${title}`),
   statusChange: (postId: number) => api.post(`api/v1/post/status/${postId}`),

--- a/src/components/common/EditProfileModal/EditPositionModal.tsx
+++ b/src/components/common/EditProfileModal/EditPositionModal.tsx
@@ -5,7 +5,6 @@ import { positionList } from '@utils/position.const';
 type valueType = {
   backgroundImageUrl: string;
   intro: string;
-  newNickname: string;
   nickname: string;
   position: string;
   profileImageUrl: string;

--- a/src/components/common/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/common/EditProfileModal/EditProfileModal.tsx
@@ -1,72 +1,55 @@
+import React, { useEffect, useState } from 'react';
+
 import './EditProfileModal.scss';
 import { EditModal } from '@components/atoms/Modal/EditModal';
-import { UserState } from '@store/user';
-import React, { useEffect, useState } from 'react';
-import { useRecoilState } from 'recoil';
+
 import { EditPositionModal } from '@components/common/EditProfileModal/EditPositionModal';
-import removeImg from '../../../assets/removeImg.svg';
-import changeImg from '../../../assets/changeImg.svg';
 import useProfileImage from '@hooks/useProfileImage';
 import { positionListKey } from '@utils/position.const';
+import { User } from 'types/user.types';
 
 import UserPostingList from './UserPostingList';
 import LikePostingList from './LikePostingList';
 
 interface IEditProfileModalProps {
+  user: User;
   isOpen: boolean;
   setIsOpen: (e: boolean) => void;
+  resetImages: () => void;
+  files: any;
+  Images: any;
+  ImgPlaceholder: any;
 }
 
 export function EditProfileModal({
+  user,
   isOpen,
   setIsOpen,
+  resetImages,
+  files,
+  Images,
+  ImgPlaceholder,
 }: IEditProfileModalProps) {
-  const [user, setUser] = useRecoilState(UserState);
   const [isEditPositionModal, setIsEditPositionModal] = useState(false);
-  const {
-    files: profileFile,
-    UploadImage: UploadProfileImage,
-    handleInitialImage: handleInitialProfileImage,
-    resetFiles: resetProfileFiles,
-  } = useProfileImage({
-    initialImage: user.profileImageUrl,
-  });
-
-  const {
-    files: backgroundFile,
-    UploadBackgroundImage,
-    ImgPlaceholder,
-    handleInitialImage: handleInitialBackgroundImage,
-    resetFiles: resetBackgroundFiles,
-  } = useProfileImage({
-    initialImage: user.backgroundImageUrl,
-  });
+  const { profileFile, backgroundFile } = files;
+  const { UploadBackgroundImage, UploadProfileImage } = Images;
 
   const [values, setValues] = useState({
-    backgroundImageUrl: '',
-    email: '',
-    intro: '',
-    newNickname: '',
-    nickname: '',
-    position: '',
-    profileImageUrl: '',
-    roleType: '',
+    backgroundImageUrl: user.backgroundImageUrl,
+    email: user.email,
+    intro: user.intro,
+    nickname: user.nickname,
+    position: positionListKey[user.position],
+    profileImageUrl: user.profileImageUrl,
+    roleType: user.roleType,
   });
 
-  useEffect(() => {
-    handleInitialData();
-  }, [user]);
-
   const handleInitialData = () => {
-    handleInitialProfileImage();
-    handleInitialBackgroundImage();
-    resetProfileFiles();
-    resetBackgroundFiles();
+    resetImages();
     setValues({
       backgroundImageUrl: user.backgroundImageUrl,
       email: user.email,
       intro: user.intro,
-      newNickname: user.nickname,
       nickname: user.nickname,
       position: positionListKey[user.position],
       profileImageUrl: user.profileImageUrl,
@@ -98,6 +81,10 @@ export function EditProfileModal({
     });
   };
 
+  const onClickSubmitBtn = (e: React.MouseEvent<HTMLDivElement>) => {
+    console.log(values);
+  };
+
   return (
     <>
       <EditModal isOpen={isOpen} setIsOpen={setIsOpen}>
@@ -113,9 +100,9 @@ export function EditProfileModal({
               </div>
               <div className="edit_myNicknameWrapper">
                 <input
-                  name="newNickname"
+                  name="nickname"
                   className="edit_myNickName"
-                  value={values.newNickname}
+                  value={values.nickname}
                   onChange={onChangeInput}
                   // placeholder="최대 5글자"
                 />
@@ -127,7 +114,7 @@ export function EditProfileModal({
               name="intro"
               className="edit_myIntro border"
               placeholder="본인에 대한 짧은 소개입니다."
-              value={values.intro}
+              value={values.intro || undefined}
               onChange={onChangeInput}
             />
             <div className="edit_myPositionWrapper">
@@ -140,7 +127,9 @@ export function EditProfileModal({
               </div>
             </div>
             <div className="edit_myBtnWrapper">
-              <div className="edit_myEditBtn">저장하기</div>
+              <div className="edit_myEditBtn" onClick={onClickSubmitBtn}>
+                저장하기
+              </div>
               <div
                 className="edit_myCancelBtn"
                 onClick={() => {

--- a/src/components/common/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/common/EditProfileModal/EditProfileModal.tsx
@@ -127,7 +127,7 @@ export function EditProfileModal({
               </div>
             </div>
             <div className="edit_myBtnWrapper">
-              <div className="edit_myEditBtn" onClick={onClickSubmitBtn}>
+              <div className="edit_myEditBtn" onClick={() => {}}>
                 저장하기
               </div>
               <div

--- a/src/components/common/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/common/EditProfileModal/EditProfileModal.tsx
@@ -81,9 +81,9 @@ export function EditProfileModal({
     });
   };
 
-  const onClickSubmitBtn = (e: React.MouseEvent<HTMLDivElement>) => {
-    console.log(values);
-  };
+  // const onClickSubmitBtn = (e: React.MouseEvent<HTMLDivElement>) => {
+  //   console.log(values);
+  // };
 
   return (
     <>

--- a/src/components/common/PostCard/PostCard.tsx
+++ b/src/components/common/PostCard/PostCard.tsx
@@ -5,62 +5,77 @@ import { IPostType } from 'types/post.types';
 import classes from './postCard.module.scss';
 import { useNavigate } from 'react-router-dom';
 import { indexOf } from 'lodash';
+import { motion, useAnimation } from 'framer-motion';
 
 interface Props {
   post: IPostType;
+  controls: any;
 }
 
-export function PostCard({ post }: Props) {
+export function PostCard({ post, controls }: Props) {
   let navigate = useNavigate();
   const clickHandlerURLParameter = () => {
     navigate(`/detail/${post.postId}`);
   };
-
+  const item = {
+    hidden: {
+      opacity: 0,
+      y: 50,
+      transition: { ease: [0.78, 0.14, 0.15, 0.86] },
+    },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: { ease: [0.78, 0.14, 0.15, 0.86] },
+    },
+  };
   return (
     <>
-      <div className={classes.postCard} onClick={clickHandlerURLParameter}>
-        <div className={classes.postWrapper}>
-          <div className={classes.postImgWrapper}>
-            <div className={classes.postImgBox}>
-              <img className={classes.img} src={post?.imageUrl} />
-            </div>
-            <div className={classes.postStatusWrapper}>
-              {post?.status === 'Y' ? (
-                <div className={classes.postStatus}>모집중</div>
-              ) : (
-                <div className={classes.postStatusNo}>모집완료</div>
-              )}
-            </div>
-          </div>
-          <div className={classes.postContentBox}>
-            <div>
-              <div className={classes.postTitle}>{post?.title}</div>
-              <div
-                className={classes.postContent}
-                dangerouslySetInnerHTML={{ __html: post?.content }}
-              ></div>
-            </div>
-            <div className={classes.postInfoBox}>
-              <div className={classes.postInfoName}>
-                {post?.position}
-                {post?.nickname}
+      <motion.li variants={item} initial="hidden" animate={controls}>
+        <div className={classes.postCard} onClick={clickHandlerURLParameter}>
+          <div className={classes.postWrapper}>
+            <div className={classes.postImgWrapper}>
+              <div className={classes.postImgBox}>
+                <img className={classes.img} src={post?.imageUrl} />
               </div>
-              <div className={classes.postIconBox}>
-                <div className={classes.postInfo}>
-                  <img src={com} />
-                  {post?.commentNum}
+              <div className={classes.postStatusWrapper}>
+                {post?.status === 'Y' ? (
+                  <div className={classes.postStatus}>모집중</div>
+                ) : (
+                  <div className={classes.postStatusNo}>모집완료</div>
+                )}
+              </div>
+            </div>
+            <div className={classes.postContentBox}>
+              <div>
+                <div className={classes.postTitle}>{post?.title}</div>
+                <div
+                  className={classes.postContent}
+                  dangerouslySetInnerHTML={{ __html: post?.content }}
+                ></div>
+              </div>
+              <div className={classes.postInfoBox}>
+                <div className={classes.postInfoName}>
+                  {post?.position}
+                  {post?.nickname}
                 </div>
-                <div className={classes.postInfo}>
-                  <img src={view} /> {post?.view}
-                </div>
-                <div className={classes.postInfo}>
-                  <img src={like} /> {post?.likeNum}
+                <div className={classes.postIconBox}>
+                  <div className={classes.postInfo}>
+                    <img src={com} />
+                    {post?.commentNum}
+                  </div>
+                  <div className={classes.postInfo}>
+                    <img src={view} /> {post?.view}
+                  </div>
+                  <div className={classes.postInfo}>
+                    <img src={like} /> {post?.likeNum}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      </motion.li>
     </>
   );
 }

--- a/src/components/common/PostList/PostList.tsx
+++ b/src/components/common/PostList/PostList.tsx
@@ -1,10 +1,9 @@
-import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { useSearchParams } from 'react-router-dom';
+import { motion, useAnimation } from 'framer-motion';
 
 import { searchState } from '@store/search';
-import { useGetPostListAPI } from '@hooks/useGetQuery';
 import useInfiniteQuerywithScroll from '@hooks/useInfiniteQuerywithScroll';
 import { ReactComponent as EllipseIcon } from '@assets/ellipse-icon.svg';
 import { ReactComponent as UpIcon } from '@assets/up-icon.svg';
@@ -13,6 +12,16 @@ import { PostAPI } from '@api/api';
 import { PostCard } from '../PostCard/PostCard';
 import { IPostType } from 'types/post.types';
 import classes from './postList.module.scss';
+
+const container = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.5,
+    },
+  },
+};
 
 export function PostList() {
   const [posts, setPosts] = useState<IPostType[]>([]);
@@ -24,13 +33,12 @@ export function PostList() {
 
   let [searchParams, setSearchParams] = useSearchParams();
 
-  const { data, isFetching, ObservationComponent } = useInfiniteQuerywithScroll(
-    {
+  const { data, isFetching, ObservationComponent, controls } =
+    useInfiniteQuerywithScroll({
       getData: PostAPI.getPostList,
       queryKey: 'postTest',
       pageSize: 5,
-    },
-  );
+    });
 
   console.log(data);
   // const { data, isFetching, refetch } = useGetPostListAPI();
@@ -77,7 +85,6 @@ export function PostList() {
 
   useEffect(() => {
     if (posts && posts.length > 0) {
-      refetch();
       setPosts([...sortingData(posts)]);
     }
   }, [selectedFilter]);
@@ -103,7 +110,7 @@ export function PostList() {
     <>
       {searchResult && searchResult.data && searchResult.data.length > 0 && (
         <div className={classes.searchResult}>
-          " {searchResult.keyword}" 에 대한 검색 결과{' '}
+          &quot; {searchResult.keyword} &quot; 에 대한 검색 결과{' '}
           <span>{searchResult.data.length}</span> 개
         </div>
       )}
@@ -149,21 +156,27 @@ export function PostList() {
             </ul>
           )}
         </div>
-        <div className={classes.postWrapper}>
-          {postsFiltered &&
-            postsFiltered.length > 0 &&
-            postsFiltered
-              .slice(0, isShowTotal ? postsFiltered.length : 8)
-              .map((post: IPostType, idx: number) => (
-                <PostCard key={`postCard-${idx}`} post={post} />
-              ))}
-          {/* <div className={classes.upIconWrapper}>
+        <motion.ul initial="hidden" animate="show" variants={container}>
+          <div className={classes.postWrapper}>
+            {postsFiltered &&
+              postsFiltered.length > 0 &&
+              postsFiltered
+                .slice(0, isShowTotal ? postsFiltered.length : 8)
+                .map((post: IPostType, idx: number) => (
+                  <PostCard
+                    key={`postCard-${idx}`}
+                    post={post}
+                    controls={controls}
+                  />
+                ))}
+            {/* <div className={classes.upIconWrapper}>
           <div className={classes.upIcon}>
             <div><UpIcon/></div>
           </div>
           </div> */}
-          <ObservationComponent />
-        </div>
+            <ObservationComponent />
+          </div>
+        </motion.ul>
       </div>
     </>
   );

--- a/src/components/common/PostList/PostList.tsx
+++ b/src/components/common/PostList/PostList.tsx
@@ -5,8 +5,10 @@ import { useSearchParams } from 'react-router-dom';
 
 import { searchState } from '@store/search';
 import { useGetPostListAPI } from '@hooks/useGetQuery';
+import useInfiniteQuerywithScroll from '@hooks/useInfiniteQuerywithScroll';
 import { ReactComponent as EllipseIcon } from '@assets/ellipse-icon.svg';
 import { ReactComponent as UpIcon } from '@assets/up-icon.svg';
+import { PostAPI } from '@api/api';
 
 import { PostCard } from '../PostCard/PostCard';
 import { IPostType } from 'types/post.types';
@@ -22,16 +24,25 @@ export function PostList() {
 
   let [searchParams, setSearchParams] = useSearchParams();
 
-  const { data, isFetching, refetch } = useGetPostListAPI();
+  const { data, isFetching, ObservationComponent } = useInfiniteQuerywithScroll(
+    {
+      getData: PostAPI.getPostList,
+      queryKey: 'postTest',
+      pageSize: 5,
+    },
+  );
+
+  console.log(data);
+  // const { data, isFetching, refetch } = useGetPostListAPI();
 
   useEffect(() => {
     if (searchResult && searchResult.data && searchResult.data.length > 0) {
       setPosts([...searchResult.data]);
       handleCategory([...searchResult.data]);
     } else {
-      if (data?.data) {
-        setPosts(data.data?.body?.data.content);
-        handleCategory(data.data?.body?.data.content);
+      if (data?.result?.content) {
+        setPosts([...posts, ...data.result.content]);
+        handleCategory([...posts, ...data.result.content]);
       }
     }
   }, [searchResult, data, categoryName]);
@@ -151,6 +162,7 @@ export function PostList() {
             <div><UpIcon/></div>
           </div>
           </div> */}
+          <ObservationComponent />
         </div>
       </div>
     </>

--- a/src/components/common/PostList/PostList.tsx
+++ b/src/components/common/PostList/PostList.tsx
@@ -40,7 +40,6 @@ export function PostList() {
       pageSize: 5,
     });
 
-  console.log(data);
   // const { data, isFetching, refetch } = useGetPostListAPI();
 
   useEffect(() => {

--- a/src/components/pages/EditPage/EditPage.tsx
+++ b/src/components/pages/EditPage/EditPage.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import {  useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 
 import { EditStudyPage } from '@components/organism';
 import { useGetPostByPostId } from '@hooks/useGetQuery';
@@ -9,23 +9,19 @@ import { IPostDetailType } from 'types/post.types';
 // 클릭한 값 보여주기
 
 function EditPage() {
-    const [initialData, setInitialData]=useState<IPostDetailType>();
+  const [initialData, setInitialData] = useState<IPostDetailType>();
 
-    let { id } = useParams();
+  let { id } = useParams();
 
-    const { data, refetch } = useGetPostByPostId(parseInt(id as string));
+  const { data, refetch } = useGetPostByPostId(parseInt(id as string));
 
-    useEffect(() => {
-        if (data && data.status === 200) {
-            console.log(data.data.body.data)
-            setInitialData(data.data.body.data);
-        }
-      }, [data, status]);
-    
+  useEffect(() => {
+    if (data && data.status === 200) {
+      setInitialData(data.data.body.data);
+    }
+  }, [data, status]);
 
-    return (
-        <EditStudyPage type="edit" initialData={initialData}/>
-    );
+  return <EditStudyPage type="edit" initialData={initialData} />;
 }
 
 export default EditPage;

--- a/src/components/pages/MyPage/MyPage.tsx
+++ b/src/components/pages/MyPage/MyPage.tsx
@@ -5,10 +5,30 @@ import React, { useState } from 'react';
 import './MyPage.scss';
 import { useRecoilState } from 'recoil';
 import { positionListKey } from '@utils/position.const';
+import useProfileImage from '@hooks/useProfileImage';
 
 function MyPage() {
   const [user, setUser] = useRecoilState(UserState);
   const [isEditProfileModal, setIsEditProfileModal] = useState(false);
+
+  const {
+    files: profileFile,
+    UploadImage: UploadProfileImage,
+    handleInitialImage: handleInitialProfileImage,
+    resetFiles: resetProfileFiles,
+  } = useProfileImage({
+    initialImage: user.profileImageUrl,
+  });
+
+  const {
+    files: backgroundFile,
+    UploadBackgroundImage,
+    ImgPlaceholder,
+    handleInitialImage: handleInitialBackgroundImage,
+    resetFiles: resetBackgroundFiles,
+  } = useProfileImage({
+    initialImage: user.backgroundImageUrl,
+  });
 
   return (
     <>
@@ -42,8 +62,24 @@ function MyPage() {
         <div className="myLine" />
       </div>
       <EditProfileModal
+        user={user}
         isOpen={isEditProfileModal}
         setIsOpen={setIsEditProfileModal}
+        resetImages={() => {
+          handleInitialProfileImage();
+          handleInitialBackgroundImage();
+          resetProfileFiles();
+          resetBackgroundFiles();
+        }}
+        files={{
+          profileFile: profileFile,
+          backgroundFile: backgroundFile,
+        }}
+        Images={{
+          UploadBackgroundImage: UploadBackgroundImage,
+          UploadProfileImage: UploadProfileImage,
+        }}
+        ImgPlaceholder={ImgPlaceholder}
       ></EditProfileModal>
     </>
   );

--- a/src/hooks/useInfiniteQuerywithScroll.tsx
+++ b/src/hooks/useInfiniteQuerywithScroll.tsx
@@ -1,0 +1,73 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+
+import { useInView } from 'react-intersection-observer';
+import { useInfiniteQuery } from 'react-query';
+
+interface useInfiniteQuerywithScrollPropsTypes {
+  getData: (pageParam: number, pageSize: number) => any;
+  queryKey: string;
+  pageSize: number;
+}
+
+interface useInfiniteQuerywithScrollReturnTypes {
+  data: any | undefined;
+  error: string | undefined | unknown;
+  isFetching: boolean;
+  ObservationComponent: () => ReactElement;
+}
+
+const useInfiniteQuerywithScroll = ({
+  getData,
+  queryKey,
+  pageSize = 5,
+}: useInfiniteQuerywithScrollPropsTypes): useInfiniteQuerywithScrollReturnTypes => {
+  const [pageParm, setPageParam] = useState(0);
+  const getDataWithPageInfo = async ({ pageParam = 0 }) => {
+    setPageParam(pageParam);
+    const content: any = await getData(pageParam, pageSize).then(
+      (res: any): any => {
+        return res.data.body.data;
+      },
+    );
+
+    const nextPage = !content.last ? pageParam + 1 : undefined;
+
+    return {
+      result: content,
+      nextPage,
+      isLast: content.last,
+    };
+  };
+
+  const { data, error, isFetching, fetchNextPage } = useInfiniteQuery(
+    [queryKey],
+    getDataWithPageInfo,
+    {
+      getNextPageParam: (lastPage) => lastPage.nextPage,
+    },
+  );
+
+  const ObservationComponent = (): ReactElement => {
+    const [ref, inView] = useInView();
+
+    useEffect(() => {
+      if (!data) return;
+
+      const pageLastIdx = data.pages.length - 1;
+      const isLast = data?.pages[pageLastIdx].isLast;
+
+      if (!isLast && inView) fetchNextPage();
+      else return;
+    }, [inView]);
+
+    return <div ref={ref} />;
+  };
+
+  return {
+    data: data?.pages[pageParm],
+    error,
+    isFetching,
+    ObservationComponent,
+  };
+};
+export default useInfiniteQuerywithScroll;

--- a/src/hooks/useInfiniteQuerywithScroll.tsx
+++ b/src/hooks/useInfiniteQuerywithScroll.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useEffect, useState } from 'react';
+import { motion, useAnimation } from 'framer-motion';
 
 import { useInView } from 'react-intersection-observer';
 import { useInfiniteQuery } from 'react-query';
@@ -13,6 +14,7 @@ interface useInfiniteQuerywithScrollReturnTypes {
   data: any | undefined;
   error: string | undefined | unknown;
   isFetching: boolean;
+  controls: any;
   ObservationComponent: () => ReactElement;
 }
 
@@ -21,6 +23,8 @@ const useInfiniteQuerywithScroll = ({
   queryKey,
   pageSize = 5,
 }: useInfiniteQuerywithScrollPropsTypes): useInfiniteQuerywithScrollReturnTypes => {
+  const controls = useAnimation();
+
   const [pageParm, setPageParam] = useState(0);
   const getDataWithPageInfo = async ({ pageParam = 0 }) => {
     setPageParam(pageParam);
@@ -60,6 +64,12 @@ const useInfiniteQuerywithScroll = ({
       else return;
     }, [inView]);
 
+    useEffect(() => {
+      if (inView) {
+        controls.start('show');
+      }
+    }, [inView, controls]);
+
     return <div ref={ref} />;
   };
 
@@ -67,6 +77,7 @@ const useInfiniteQuerywithScroll = ({
     data: data?.pages[pageParm],
     error,
     isFetching,
+    controls,
     ObservationComponent,
   };
 };

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -1,0 +1,9 @@
+export type User = {
+  backgroundImageUrl: string;
+  email: string;
+  intro: string;
+  nickname: string;
+  position: string;
+  profileImageUrl: string;
+  roleType: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,12 +280,24 @@
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.1.0", "@emotion/is-prop-valid@^1.1.3":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.3.tgz"
   integrity sha512-RFg04p6C+1uO19uG8N+vqanzKqiM9eeV1LDOG3bmkYmuOj7NbKNlFC/4EZq5gnwAIlcC/jOT24f8Td0iax2SXA==
   dependencies:
     "@emotion/memoize" "^0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
   version "0.7.5"
@@ -432,6 +444,59 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@motionone/animation@^10.13.1":
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/@motionone/animation/-/animation-10.13.2.tgz#174a55a3bac1b6fb314cc1c3627093dc790ae081"
+  integrity sha512-YGWss58IR2X4lOjW89rv1Q+/Nq/QhfltaggI7i8sZTpKC1yUvM+XYDdvlRpWc6dk8LviMBrddBJAlLdbaqeRmw==
+  dependencies:
+    "@motionone/easing" "^10.13.2"
+    "@motionone/types" "^10.13.2"
+    "@motionone/utils" "^10.13.2"
+    tslib "^2.3.1"
+
+"@motionone/dom@10.13.1":
+  version "10.13.1"
+  resolved "https://registry.yarnpkg.com/@motionone/dom/-/dom-10.13.1.tgz#fc29ea5d12538f21b211b3168e502cfc07a24882"
+  integrity sha512-zjfX+AGMIt/fIqd/SL1Lj93S6AiJsEA3oc5M9VkUr+Gz+juRmYN1vfvZd6MvEkSqEjwPQgcjN7rGZHrDB9APfQ==
+  dependencies:
+    "@motionone/animation" "^10.13.1"
+    "@motionone/generators" "^10.13.1"
+    "@motionone/types" "^10.13.0"
+    "@motionone/utils" "^10.13.1"
+    hey-listen "^1.0.8"
+    tslib "^2.3.1"
+
+"@motionone/easing@^10.13.2":
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/@motionone/easing/-/easing-10.13.2.tgz#8f10c8624000eb741312941d3f578ed05154e06f"
+  integrity sha512-3HqctS5NyDfDQ+8+cZqc3Pu7I6amFCt9zDUjcozHyFXHh4PKYHK4+GJDFjJIS8bCAF2BrJmpmduDQ2V7lFEYeQ==
+  dependencies:
+    "@motionone/utils" "^10.13.2"
+    tslib "^2.3.1"
+
+"@motionone/generators@^10.13.1":
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/@motionone/generators/-/generators-10.13.2.tgz#dd972195b899e7a556d65bd27fae2fd423055e10"
+  integrity sha512-QMoXV1MXEEhR6D3dct/RMMS1FwJlAsW+kMPbFGzBA4NbweblgeYQCft9DcDAVpV9wIwD6qvlBG9u99sOXLfHiA==
+  dependencies:
+    "@motionone/types" "^10.13.2"
+    "@motionone/utils" "^10.13.2"
+    tslib "^2.3.1"
+
+"@motionone/types@^10.13.0", "@motionone/types@^10.13.2":
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/@motionone/types/-/types-10.13.2.tgz#c560090d81bd0149e7451aae23ab7af458570363"
+  integrity sha512-yYV4q5v5F0iADhab4wHfqaRJnM/eVtQLjUPhyEcS72aUz/xyOzi09GzD/Gu+K506BDfqn5eULIilUI77QNaqhw==
+
+"@motionone/utils@^10.13.1", "@motionone/utils@^10.13.2":
+  version "10.13.2"
+  resolved "https://registry.yarnpkg.com/@motionone/utils/-/utils-10.13.2.tgz#ce79bfe1d133493c217cdc0584960434e065648d"
+  integrity sha512-6Lw5bDA/w7lrPmT/jYWQ76lkHlHs9fl2NZpJ22cVy1kKDdEH+Cl1U6hMTpdphO6VQktQ6v2APngag91WBKLqlA==
+  dependencies:
+    "@motionone/types" "^10.13.2"
+    hey-listen "^1.0.8"
+    tslib "^2.3.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1963,6 +2028,27 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+framer-motion@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-7.0.0.tgz#5fb580d0fe5a2a3ec055d2b7b5b57313a96683b7"
+  integrity sha512-mOUKle6LouYVP4KLz+cMiNI6fL3qP9hQY4PBaN3E1FyPhcvuAgvs/JPgYktvK5zdRbIRU0gpBsr0CW5hP2KzKA==
+  dependencies:
+    "@motionone/dom" "10.13.1"
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    popmotion "11.0.3"
+    style-value-types "5.1.0"
+    tslib "^2.1.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
+framesync@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
+  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
+  dependencies:
+    tslib "^2.1.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz"
@@ -2234,6 +2320,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+hey-listen@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
+  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 history@^5.2.0:
   version "5.3.0"
@@ -3169,6 +3260,16 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.0, picomatc
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+popmotion@11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
+  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
+  dependencies:
+    framesync "6.0.1"
+    hey-listen "^1.0.8"
+    style-value-types "5.0.0"
+    tslib "^2.1.0"
+
 postcss-value-parser@^4.0.2:
   version "4.2.0"
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz"
@@ -3845,6 +3946,22 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
+style-value-types@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
+  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^2.1.0"
+
+style-value-types@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.1.0.tgz#228b02bd9418c57db46c1f450b85577e634a877f"
+  integrity sha512-DRIfBtjxQ4ztBZpexkFcI+UR7pODC5qLMf2Syt+bH98PAHHRH2tQnzxBuDQlqcAoYar6GzWnj8iAfqfwnEzCiQ==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^2.3.1"
+
 styled-components@^5.3.5:
   version "5.3.5"
   resolved "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz"
@@ -3957,6 +4074,11 @@ tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0, tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,12 +2652,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.4:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.17.21:
+lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3290,6 +3285,11 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-intersection-observer@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-9.4.0.tgz#f6b6e616e625f9bf255857c5cba9dbf7b1825ec7"
+  integrity sha512-v0403CmomOVlzhqFXlzOxg0ziLcVq8mfbP0AwAcEQWgZmR2OulOT79Ikznw4UlB3N+jlUYqLMe4SDHUOyp0t2A==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용

- [x] 메인페이지 무한 스크롤 구현
react query 의 `useInfiniteQuery` 와 `react-intersection-observer` 를 사용해 무한스크롤 기능을 구현했습니다.
해당 기능은 useInfiniteQuerywithScroll 이라는 커스텀훅으로 개발해, 다른 곳에서 재사용할 수 있도록 개발했습니다. react-interseciton observer 의 useInView() 훅을 사용해, 마지막 요소를 감지했고, 페이지네이션 원리에따라 마지막 페이지가 아닐 경우 fetchNextPage() 함수를 호출해 기존 데이터 리스트에 추가되도록 개발했습니다. 

- [x] 무한스크롤 애니메이션 구현
framer-motion 을 사용해 무한스크롤 애니메이션을 구현했습니다. 


- [x] useProfileImage 재렌더링 버그 해결
useProfileImage 커스텀 훅을 input state 를 관리하는 컴포넌트와 동일한 레벨에서 호출해, 입력값 상태가 바뀔 때마다 useProfileImage 함수가 재 할당되어 프로필 사진이 깜빡거리는 이슈가 있었습니다. useProfileImage 커스텀 훅을 상위 컴포넌트에 선언해 해당 이슈를 해결했습니다.



<br>

## 💻 변경 내용

- 내용을 적어주세요.

<br>

## ✅ 관심 리뷰

- 내용을 적어주세요.
  ~
