### PR TITLE
[Feat/i39] 마이페이지 수정 모달 기능 개발 완료

### DIFF
--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -68,12 +68,18 @@ export const CategoryAPI = {
 
 export const UserAPI = {
   getUserInfo: () => api.get('/api/v1/info'),
-  updateUserInfo: (form: any) =>
+  addUserInfo: (form: any) =>
     api.post('/api/v1/info', form, {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
     }),
+  updateUserInfo : (form:any)=>
+  api.put('/api/v1/info', form, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  }),
   validateNickname: (nickname: string) =>
     api.post('/api/v1/validate/nickname', { nickname: nickname }),
 };

--- a/src/components/common/EditProfileModal/EditPositionModal.tsx
+++ b/src/components/common/EditProfileModal/EditPositionModal.tsx
@@ -2,12 +2,13 @@ import { EditModal } from '@components/atoms/Modal/EditModal';
 import { Select } from '../Select/Select';
 import React, { useEffect, useState } from 'react';
 import { positionList } from '@utils/position.const';
+
 type valueType = {
-  backgroundImageUrl: string;
+  backgroundImage: any;
   intro: string;
   nickname: string;
   position: string;
-  profileImageUrl: string;
+  profileImage: any;
 };
 interface IEditPositionModalProps {
   isOpen: boolean;

--- a/src/components/common/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/common/EditProfileModal/EditProfileModal.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Swal from 'sweetalert2';
 
 import './EditProfileModal.scss';
 import { EditModal } from '@components/atoms/Modal/EditModal';
@@ -92,10 +93,21 @@ export function EditProfileModal({
     }
 
     await useUpdateUserMutate.mutateAsync(formData)
-                             .then((res)=>console.log(res))
+                             .then(handleSuccess)
                               .catch((err)=>console.log(err))
-
   };
+
+  const handleSuccess = ()=>{
+    Swal.fire({
+      title: '수정 완료!',
+      text: '마이페이지에서 확인하세요',
+      icon: 'success',
+      confirmButtonText: '<a href = "/">확인</a>',
+    }).then((result) => {
+      setIsOpen(false);
+    });
+
+  }
 
   const handleFormData=(values:UpdateUser)=>{
 

--- a/src/components/common/EditProfileModal/EditProfileModal.tsx
+++ b/src/components/common/EditProfileModal/EditProfileModal.tsx
@@ -4,15 +4,16 @@ import './EditProfileModal.scss';
 import { EditModal } from '@components/atoms/Modal/EditModal';
 
 import { EditPositionModal } from '@components/common/EditProfileModal/EditPositionModal';
-import useProfileImage from '@hooks/useProfileImage';
-import { positionListKey } from '@utils/position.const';
-import { User } from 'types/user.types';
+
+import { positionListKey, positionList } from '@utils/position.const';
+import { UpdateUser, User } from 'types/user.types';
 
 import UserPostingList from './UserPostingList';
 import LikePostingList from './LikePostingList';
 
+import {useUpdateUser} from '@hooks/useMutateQuery';
 interface IEditProfileModalProps {
-  user: User;
+  user: User ;
   isOpen: boolean;
   setIsOpen: (e: boolean) => void;
   resetImages: () => void;
@@ -34,25 +35,27 @@ export function EditProfileModal({
   const { profileFile, backgroundFile } = files;
   const { UploadBackgroundImage, UploadProfileImage } = Images;
 
+  const useUpdateUserMutate =useUpdateUser();
+
   const [values, setValues] = useState({
-    backgroundImageUrl: user.backgroundImageUrl,
+    backgroundImage: undefined,
     email: user.email,
     intro: user.intro,
     nickname: user.nickname,
     position: positionListKey[user.position],
-    profileImageUrl: user.profileImageUrl,
+    profileImage: undefined,
     roleType: user.roleType,
   });
 
   const handleInitialData = () => {
     resetImages();
     setValues({
-      backgroundImageUrl: user.backgroundImageUrl,
+      backgroundImage: undefined,
       email: user.email,
       intro: user.intro,
       nickname: user.nickname,
       position: positionListKey[user.position],
-      profileImageUrl: user.profileImageUrl,
+      profileImage: undefined,
       roleType: user.roleType,
     });
   };
@@ -60,14 +63,14 @@ export function EditProfileModal({
   useEffect(() => {
     setValues({
       ...values,
-      ['profileImageUrl']: profileFile,
+      ['profileImage']: profileFile,
     });
   }, [profileFile]);
 
   useEffect(() => {
     setValues({
       ...values,
-      ['backgroundImageUrl']: backgroundFile,
+      ['backgroundImage']: backgroundFile,
     });
   }, [backgroundFile]);
 
@@ -81,9 +84,50 @@ export function EditProfileModal({
     });
   };
 
-  // const onClickSubmitBtn = (e: React.MouseEvent<HTMLDivElement>) => {
-  //   console.log(values);
-  // };
+  const onClickSubmitBtn = async(e: React.MouseEvent<HTMLDivElement>) => {
+    let newFormData = handleFormData(values);
+    let formData = new FormData();
+    for (const [key, value] of Object.entries(newFormData)) {
+      formData.append(key, value);
+    }
+
+    await useUpdateUserMutate.mutateAsync(formData)
+                             .then((res)=>console.log(res))
+                              .catch((err)=>console.log(err))
+
+  };
+
+  const handleFormData=(values:UpdateUser)=>{
+
+    let newFormData= {
+      intro: values.intro,
+      nickname : values.nickname,
+      position: positionList[values.position],
+    } as UpdateUser;
+
+
+    if(values.profileImage !==  undefined){
+      newFormData["keepProfileImage"] = "N"
+      newFormData["profileImage"] = values.profileImage;
+    }
+    else{
+      let blob = new Blob();
+      newFormData["keepProfileImage"] = "Y"
+      newFormData["profileImage"] = blob;
+    }
+
+    if(values.backgroundImage !== undefined){
+      newFormData["keepBackgroundImage"] = "N";
+      newFormData["backgroundImage"] = values.backgroundImage;
+    }
+    else{
+      let blob = new Blob();
+      newFormData["keepBackgroundImage"] = "Y";
+      newFormData["backgroundImage"] = blob;
+    }
+
+    return newFormData;
+  }
 
   return (
     <>
@@ -127,7 +171,7 @@ export function EditProfileModal({
               </div>
             </div>
             <div className="edit_myBtnWrapper">
-              <div className="edit_myEditBtn" onClick={() => {}}>
+              <div className="edit_myEditBtn" onClick={onClickSubmitBtn}>
                 저장하기
               </div>
               <div

--- a/src/components/common/PostList/PostList.tsx
+++ b/src/components/common/PostList/PostList.tsx
@@ -39,10 +39,8 @@ export function PostList() {
       queryKey: 'postTest',
       pageSize: 5,
     });
-    console.log(data);
 
-  // const { data, isFetching, refetch } = useGetPostListAPI();
-
+    
   useEffect(() => {
     if (searchResult && searchResult.data && searchResult.data.length > 0) {
       setPosts([...searchResult.data]);

--- a/src/components/pages/MyPage/MyPage.tsx
+++ b/src/components/pages/MyPage/MyPage.tsx
@@ -1,23 +1,33 @@
-import { SignInModal } from '@components/common';
-import { EditProfileModal } from '@components/common/EditProfileModal/EditProfileModal';
-import { UserState } from '@store/user';
-import React, { useState } from 'react';
+
+import React, { useState, useEffect} from 'react';
 import './MyPage.scss';
-import { useRecoilState } from 'recoil';
+
+import { EditProfileModal } from '@components/common/EditProfileModal/EditProfileModal';
 import { positionListKey } from '@utils/position.const';
+
 import useProfileImage from '@hooks/useProfileImage';
+import {useGetUserAPI} from '@hooks/useGetQuery';
+import {User} from 'types/user.types';
 
 function MyPage() {
-  const [user, setUser] = useRecoilState(UserState);
+  // const [user, setUser] = useRecoilState(UserState);
+  const [user, setUser]=useState<User>();
   const [isEditProfileModal, setIsEditProfileModal] = useState(false);
+  const {data} = useGetUserAPI();
 
+  useEffect(()=>{
+    if(data && data.status===200){
+      setUser(data.data.body.data);
+    }
+  },[data])
+  
   const {
     files: profileFile,
     UploadImage: UploadProfileImage,
     handleInitialImage: handleInitialProfileImage,
     resetFiles: resetProfileFiles,
   } = useProfileImage({
-    initialImage: user.profileImageUrl,
+    initialImage: user?.profileImageUrl,
   });
 
   const {
@@ -27,15 +37,21 @@ function MyPage() {
     handleInitialImage: handleInitialBackgroundImage,
     resetFiles: resetBackgroundFiles,
   } = useProfileImage({
-    initialImage: user.backgroundImageUrl,
+    initialImage: user?.backgroundImageUrl,
   });
 
   return (
     <>
       <div className="myPageWrapper">
         <div className="myProfileWrapper">
-          <div className="myPageBackground">
-            <img className="myProfileImg" src={user.profileImageUrl} />
+          <div className="myPageBackground"
+            style={{
+              backgroundRepeat: 'no-repeat',
+              backgroundSize : 'cover',
+              backgroundImage : `url(${user?.backgroundImageUrl})`
+            }}
+          >
+            <img className="myProfileImg" src={user?.profileImageUrl} />
             <button
               className="myEditProfile"
               onClick={() => setIsEditProfileModal(true)}
@@ -43,17 +59,15 @@ function MyPage() {
               프로필 수정
             </button>
           </div>
-          <div className="myNickName">{user.nickname}</div>
-          <div className="myInfo">{user.roleType}</div>
-          <div className="myInfo">{user.email}</div>
+          <div className="myNickName">{user?.nickname}</div>
+          <div className="myInfo">{user?.roleType}</div>
+          <div className="myInfo">{user?.email}</div>
         </div>
         <div className="myIntro">
-          본인에 대한 짧은 소개입니다.본인에 대한 짧은 소개입니다.본인에 대한
-          짧은 소개입니다. 본인에 대한 짧은 소개입니다.본인에 대한 짧은
-          소개입니다.
+          {user?.intro}
         </div>
         <div className="myPositionWrapper">
-          <div className="myPosition">{positionListKey[user.position]}</div>
+          <div className="myPosition">{positionListKey[user?.position as string]}</div>
         </div>
         <div className="myPostsWrapper">
           <div className="myPosts">작성한 글 보기</div>
@@ -61,6 +75,7 @@ function MyPage() {
         </div>
         <div className="myLine" />
       </div>
+      {user&&
       <EditProfileModal
         user={user}
         isOpen={isEditProfileModal}
@@ -81,6 +96,7 @@ function MyPage() {
         }}
         ImgPlaceholder={ImgPlaceholder}
       ></EditProfileModal>
+    }
     </>
   );
 }

--- a/src/hooks/useMutateQuery.tsx
+++ b/src/hooks/useMutateQuery.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "react-query";
 
 export const useAddUserInfo =()=>{
     const queryClient = useQueryClient();
-    return useMutation((form:any)=>UserAPI.updateUserInfo(form),{
+    return useMutation((form:any)=>UserAPI.addUserInfo(form),{
         onSuccess: ()=>queryClient.invalidateQueries("user")
     })
 }
@@ -52,5 +52,12 @@ export const useDeleteReply =(postId:number, replyId:number)=>{
     const queryClient = useQueryClient();
     return useMutation(()=>ReplyAPI.deleteReply(replyId),{
         onSuccess: ()=>queryClient.invalidateQueries(["post", postId])
+    })
+}
+
+export const useUpdateUser = ()=>{
+    const queryClient = useQueryClient();
+    return useMutation((form:any)=>UserAPI.updateUserInfo(form),{
+        onSuccess: ()=>queryClient.invalidateQueries("user")
     })
 }

--- a/src/hooks/useProfileImage.tsx
+++ b/src/hooks/useProfileImage.tsx
@@ -31,6 +31,7 @@ export default function useUploadImage(props: any) {
 
   const handleInitialImage = () => {
     const imgEl = ImgPlaceholder.current as HTMLDivElement;
+    // setFiles(undefined);
     if (!imgEl) return;
     imgEl.style.backgroundRepeat = 'no-repeat';
     imgEl.style.backgroundSize = 'cover';

--- a/src/hooks/useProfileImage.tsx
+++ b/src/hooks/useProfileImage.tsx
@@ -1,6 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useRecoilState } from 'recoil';
-import { UserState } from '@store/user';
 
 import removeImg from '../assets/removeImg.svg';
 import changeImg from '../assets/changeImg.svg';

--- a/src/types/user.types.ts
+++ b/src/types/user.types.ts
@@ -7,3 +7,16 @@ export type User = {
   profileImageUrl: string;
   roleType: string;
 };
+
+
+export type UpdateUser = {
+  backgroundImage: any;
+  email: string;
+  intro: string;
+  nickname: string;
+  position: string;
+  profileImage: any,
+  roleType: string;
+  keepProfileImage? : "Y" | "N";
+  keepBackgroundImage? : "Y" | "N";
+};


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용

**-  유저 정보 수정 API 연결 완료**
이슈 : backgroundImage. profileImage 를 변경하지 않고 넘어갈 경우, 빈 스트링 ('') 으로 요청보낼 경우, data type 이 맞지 않아 400에러 발생. 
해결 : 변경하지 않고 넘어갈 경우 빈 blob 객체 let blob= new Blob(); 을 생성해 넘겨주도록 예외처리.

**- 유저 정보 페이지 서버 상태관련 코드 React Query 로 변경**
이슈: 새로고침할 때마다 recoil 상태가 날라가, 빈페이지로 보이는 이슈 발생
해결 : recoil 에서 불러오던 유저 정보를 react query key 값으로 가져오도록 코드 변경

**- 유저정보 수정 후 stale 데이터 업데이트**
이슈 : axios 사용해서 수정했을 경우 성공시, 분산되어 있는 유저 관련된 정보를 한번에 update 하는 부분에서 어려움이 있었음.
해결 : react query invalidateQuery 를 사용해 mutate 성공시 stale 데이터 업데이트되도록 수정

<br>

## 💻 변경 내용

- 내용을 적어주세요.

<br>

## ✅ 관심 리뷰

- 내용을 적어주세요.
  ~
