### PR TITLE
Feat: 헤더 우측에 위치한 유저 네비게이션 DropDown 이슈 해결

### DIFF
--- a/src/components/common/login/LoginOauth.tsx
+++ b/src/components/common/login/LoginOauth.tsx
@@ -6,8 +6,6 @@ import { useEffect } from 'react';
 function LoginOauth() {
   const [login, setLogin] = useRecoilState(loginState);
   const navigate = useNavigate();
-
-  //token 받기
   const token = new URL(window.location.href).searchParams.get('token');
 
   // token localstorage 저장
@@ -16,15 +14,16 @@ function LoginOauth() {
 
   localStorage.setItem('loginData', obj);
 
-  //login token 담길시 새로고침
+  // login token 담길시 새로고침
+  // 0min: 새로 고침이 아니라 url만 변경해 주는 것
   useEffect(() => {
-    document.location.href = '/';
+    // document.location.href = '/';
+    navigate('/');
   }, [login]);
 
-  return (
-    // <div></div>
-    <Link to="/">메인으로 이동</Link>
-  );
+  // Link tag를 반환할 필요가 있는가?
+  return null;
+  // return <Link to="/">메인으로 이동</Link>;
 }
 
 export default LoginOauth;

--- a/src/components/common/main/DropDown/UserDropDown.tsx
+++ b/src/components/common/main/DropDown/UserDropDown.tsx
@@ -1,0 +1,56 @@
+import { useLogout } from '@hooks/useLogout';
+import { UserState } from '@store/user';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import classes from './userDropDown.module.scss';
+
+interface HeaderDropDownProps {
+  isOpen: boolean;
+  close: () => void;
+}
+export const HeaderDropDown = ({ isOpen, close }: HeaderDropDownProps) => {
+  const user = useRecoilValue(UserState);
+  const navigate = useNavigate();
+  const handleLogount = useLogout();
+  const options: [string, () => void][] =
+    user.roleType === 'adming'
+      ? [
+          ['관리자 페이지', () => {}],
+          ['로그아웃', () => handleLogount()],
+        ]
+      : [
+          [
+            '내 정보 수정',
+            () => {
+              navigate('mypage');
+              close();
+            },
+          ],
+          ['로그아웃', () => handleLogount()],
+        ];
+
+  return isOpen && user ? (
+    <div className={classes.dropDownContainer}>
+      <div className={classes.dropDownWrap}>
+        <div className={classes.dropDownSection}>
+          <div className={classes.dropDownTitle}>
+            <h1>{user.nickname}</h1>
+          </div>
+          <div className={classes.dropDownSubTitle}>
+            <p>{user.roleType}</p>
+            <p>{user.email}</p>
+          </div>
+        </div>
+        <div className={classes.dropDownOptions}>
+          <ul>
+            {options.map(([text, onClick]) => (
+              <li key={text} onClick={onClick}>
+                {text}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  ) : null;
+};

--- a/src/components/common/main/DropDown/userDropDown.module.scss
+++ b/src/components/common/main/DropDown/userDropDown.module.scss
@@ -1,0 +1,50 @@
+.dropDownContainer {
+  position: relative;
+  .dropDownWrap {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background: #ffffff;
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
+    // padding: 0 30px;
+    border-radius: 5px;
+
+    .dropDownSection {
+      padding: 20px 30px;
+      .dropDownTitle {
+        display: flex;
+        align-items: center;
+        height: 50px;
+        font-size: 25px;
+        font-weight: 600;
+      }
+      .dropDownSubTitle {
+        text-align: left;
+        font-size: 16px;
+        font-weight: 400;
+        color: #767676;
+        & p:first-child {
+          margin-bottom: 5px;
+        }
+      }
+    }
+
+    .dropDownOptions {
+      & ul {
+        width: 300px;
+        display: inherit;
+        text-align: left;
+        list-style: none;
+      }
+      li {
+        margin: 0;
+        padding: 20px 30px;
+        border-top: 1px solid #e6e6e6;
+        &:hover {
+          cursor: pointer;
+          box-shadow: inset 0 1000px rgba(0, 0, 0, 0.03);
+        }
+      }
+    }
+  }
+}

--- a/src/components/common/main/Header/Header.tsx
+++ b/src/components/common/main/Header/Header.tsx
@@ -1,24 +1,23 @@
 import { AlarmIcon } from '@components/common';
-import React, { useEffect, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { UserState, loginState } from '@store/index';
-import { defaultUserState } from '@store/user';
-import { OnboardModal, SignInModal, ToggleIcon } from '@components/common';
-import Swal from 'sweetalert2';
+import { OnboardModal, SignInModal } from '@components/common';
+import { NewIcon } from '@components/atoms/Icon/NewIcon';
+import { HeaderUserProfileNav } from './HeaderUserProfileNav';
 import logo from '@assets/toteelogo-kr.png';
 import alarm from '@assets/alarmicon.svg';
 import './header.scss';
-import { NewIcon } from '@components/atoms/Icon/NewIcon';
 
 export const Header = () => {
-  const [listening, setListening] = useState(false);
-  const [meventSource, msetEventSource] = useState<any>(undefined);
+  // const [listening, setListening] = useState(false);
+  // const [meventSource, msetEventSource] = useState<any>(undefined);
 
   const [isOpenLoginModal, setIsOpenLoginModal] = useState(false);
   const [isOpenOnboardModal, setIsOpenOnboardModal] = useState(false);
-  const [isShowToggle, setIsShowToggle] = useState(false);
   const [isShowAlarm, setIsShowAlarm] = useState(false);
+  // const [isShowToggle, setIsShowToggle] = useState(false);
 
   //로그인 state 관리
   const [login, setLogin] = useRecoilState(loginState);
@@ -34,22 +33,22 @@ export const Header = () => {
   };
 
   //로그아웃 버튼
-  const handleLogout = () => {
-    Swal.fire({
-      position: 'top-end',
-      icon: 'success',
-      title: '로그아웃 완료!',
-      iconColor: '#f48484',
-      showConfirmButton: false,
-      timer: 1100,
-    });
-    localStorage.removeItem('loginData');
-    setLogin({
-      state: false,
-      token: '',
-    });
-    setUser({ ...defaultUserState });
-  };
+  // const handleLogout = () => {
+  //   Swal.fire({
+  //     position: 'top-end',
+  //     icon: 'success',
+  //     title: '로그아웃 완료!',
+  //     iconColor: '#f48484',
+  //     showConfirmButton: false,
+  //     timer: 1100,
+  //   });
+  //   localStorage.removeItem('loginData');
+  //   setLogin({
+  //     state: false,
+  //     token: '',
+  //   });
+  //   setUser({ ...defaultUserState });
+  // };
 
   useEffect(() => {
     // 첫방문일 경우 온보딩 모달 띄우기
@@ -81,12 +80,11 @@ export const Header = () => {
     //   setListening(true);
     // }
 
-    return () => {
-      if (listening && eventSource) {
-        eventSource.close();
-        console.log('eventsource closed');
-      }
-    };
+    // return () => {
+    //   if (listening && eventSource) {
+    //     eventSource.close();
+    //   }
+    // };
 
     //구독
   }, [user, login]);
@@ -95,18 +93,11 @@ export const Header = () => {
     <>
       <header className="header">
         <div className="content">
-          <NewIcon
-            // <img
-            src={logo}
-            alt="토티 로고"
-            onClick={() => navigate('/')}
-            // onClick={() => (window.location.href = '/')}
-          />
+          <NewIcon src={logo} alt="토티 로고" onClick={() => navigate('/')} />
           <div className="buttonWrapper">
             <ul className="profile_wrapper">
               <li>
                 {!login.state ? null : (
-                  // <img src={alarm} className="alarmButton" />
                   <>
                     <AlarmIcon
                       imageUrl={alarm}
@@ -117,16 +108,22 @@ export const Header = () => {
                   </>
                 )}
               </li>
-              {['스터디 개설', '멘토 지원'].map((text) => (
-                <li key={text}>
-                  <button
-                    className="createStudyButton"
-                    onClick={handleStudyClick}
-                  >
-                    {text}
-                  </button>
-                </li>
-              ))}
+              <li>
+                <button
+                  className="createStudyButton"
+                  onClick={handleStudyClick}
+                >
+                  스터디 개설
+                </button>
+              </li>
+              <li>
+                <button
+                  className="createStudyButton"
+                  onClick={() => navigate('reading')}
+                >
+                  멘토 지원
+                </button>
+              </li>
               <li className="line" />
               <li>
                 {!login.state ? (
@@ -137,21 +134,7 @@ export const Header = () => {
                     로그인
                   </button>
                 ) : (
-                  <>
-                    <ToggleIcon
-                      imageUrl={user.profileImageUrl}
-                      style={{ width: '65px', height: '65px' }}
-                      userInfo={{
-                        roleType: user.roleType,
-                        nickname: user.nickname,
-                        email: user.email,
-                      }}
-                      handleLogout={handleLogout}
-                      isShowToggle={isShowToggle}
-                      setIsShowToggle={setIsShowToggle}
-                      onClick={() => setIsShowToggle(!isShowToggle)}
-                    ></ToggleIcon>
-                  </>
+                  <HeaderUserProfileNav />
                 )}
               </li>
             </ul>

--- a/src/components/common/main/Header/HeaderUserProfileNav.tsx
+++ b/src/components/common/main/Header/HeaderUserProfileNav.tsx
@@ -1,0 +1,26 @@
+import { useOutsideAlerter } from '@hooks/useOutsideAlerter';
+import { UserState } from '@store/user';
+import { useRef, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { HeaderDropDown } from '../DropDown/UserDropDown';
+import { ToggleIcon } from '../ToggleIcon/ToggleIcon';
+
+export const HeaderUserProfileNav = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleRef = useRef(null);
+  const user = useRecoilValue(UserState);
+  const toggle = () => setIsOpen((pre) => !pre);
+  const close = () => setIsOpen(false);
+  useOutsideAlerter(toggleRef, close);
+
+  return (
+    <div ref={toggleRef}>
+      <ToggleIcon
+        imageUrl={user.profileImageUrl}
+        style={{ width: '65px', height: '65px' }}
+        onClick={toggle}
+      />
+      <HeaderDropDown isOpen={isOpen} close={close} />
+    </div>
+  );
+};

--- a/src/components/common/main/ToggleIcon/ToggleIcon.tsx
+++ b/src/components/common/main/ToggleIcon/ToggleIcon.tsx
@@ -1,69 +1,27 @@
-import { useRef } from 'react';
-import { Link } from 'react-router-dom';
 import { NewIcon } from '@components/atoms/Icon/NewIcon';
-import { useOutsideAlerter } from '@hooks/useOutsideAlerter';
 import DownIcon from '@assets/toggle-icon.svg';
 import { ToggleIconProps } from 'types/icon.types';
 import classes from './toggleIcon.module.scss';
 
-export function ToggleIcon({
-  imageUrl,
-  userInfo,
-  handleLogout,
-  isShowToggle,
-  setIsShowToggle,
-}: ToggleIconProps) {
-  const toggleRef = useRef(null as any);
-  const toggleOnClick = () => setIsShowToggle(!isShowToggle);
-  const toggleWithLogoutOnClick = () => {
-    toggleOnClick();
-    handleLogout();
-  };
-  useOutsideAlerter(toggleRef, () => setIsShowToggle(false));
-
+export function ToggleIcon({ imageUrl, onClick }: ToggleIconProps) {
   return (
-    <>
-      <span ref={toggleRef}>
-        <div className={classes.flex}>
-          <NewIcon
-            src={imageUrl}
-            alt="user_profile_img"
-            style={{ width: '60px', height: '60px', borderRadius: '50%' }}
-            onClick={toggleOnClick}
-          />
-          <NewIcon
-            src={DownIcon}
-            className="DownIcon"
-            alt="down_toggle_icon"
-            width={20}
-            height={20}
-            onClick={toggleOnClick}
-          />
-        </div>
-        {isShowToggle && (
-          <div className={classes.toggleWrapper}>
-            <div className={classes.toggleContainer}>
-              <section className={classes.userInfo}>
-                <h1>{userInfo.nickname}</h1>
-                <div>
-                  <p>{userInfo.roleType}</p>
-                  <p>{userInfo.email}</p>
-                </div>
-              </section>
-              <ul>
-                {userInfo.roleType !== 'USER' ? (
-                  <li>관리자 페이지</li>
-                ) : (
-                  <Link to="/mypage">
-                    <li onClick={toggleOnClick}>내 정보 수정</li>
-                  </Link>
-                )}
-                <li onClick={toggleWithLogoutOnClick}>로그아웃</li>
-              </ul>
-            </div>
-          </div>
-        )}
-      </span>
-    </>
+    <span>
+      <div className={classes.flex}>
+        <NewIcon
+          src={imageUrl}
+          alt="user_profile_img"
+          style={{ width: '60px', height: '60px', borderRadius: '50%' }}
+          onClick={onClick}
+        />
+        <NewIcon
+          src={DownIcon}
+          className="DownIcon"
+          alt="down_toggle_icon"
+          width={20}
+          height={20}
+          onClick={onClick}
+        />
+      </div>
+    </span>
   );
 }

--- a/src/hooks/useLogout.tsx
+++ b/src/hooks/useLogout.tsx
@@ -1,0 +1,35 @@
+import { loginState } from '@store/login';
+import { UserState } from '@store/user';
+import { useNavigate } from 'react-router-dom';
+import { Resetter, useResetRecoilState } from 'recoil';
+import Swal from 'sweetalert2';
+
+export const useLogout = (url: string = '/') => {
+  const resetUser = useResetRecoilState(UserState);
+  const resetLogin = useResetRecoilState(loginState);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    fireLogoutSwal();
+    localStorage.removeItem('loginData');
+    resetRecoilStates([resetUser, resetLogin]);
+    navigate(url);
+  };
+
+  const fireLogoutSwal = () => {
+    Swal.fire({
+      position: 'top-end',
+      icon: 'success',
+      title: '로그아웃 완료!',
+      iconColor: '#f48484',
+      showConfirmButton: false,
+      timer: 1100,
+    });
+  };
+
+  const resetRecoilStates = (recoilStates: Resetter[]) => {
+    recoilStates.forEach((resetFuncion) => resetFuncion());
+  };
+
+  return handleLogout;
+};

--- a/src/types/icon.types.ts
+++ b/src/types/icon.types.ts
@@ -8,14 +8,16 @@ export interface IIconProps {
 }
 
 export interface ToggleIconProps extends IIconProps {
-  userInfo: {
-    nickname: string;
-    email: string;
-    roleType: string;
-  };
-  handleLogout: () => void;
-  isShowToggle: boolean;
-  setIsShowToggle: (e: boolean) => void;
+  // export interface ToggleIconProps {
+  // userInfo: {
+  //   nickname: string;
+  //   email: string;
+  //   roleType: string;
+  // };
+  // handleLogout: () => void;
+  // isShowToggle: boolean;
+  // setIsShowToggle: (e: boolean) => void;
+  // toggleIsOpen: () => void;
 }
 
 export interface AlarmIconProps {


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용
- user api의 response가 변경됨에 따라 진행된 헤더 우측에 위치한 **유저 관련 네비게이션 드롭다운**에 대한 이슈해결 Front 작업입니다.


<br>

## 💻 변경 내용
기존의 Header Component는 코드의 복잡성이 높고 하는 역할이 많았기에 이를 분리했습니다.
1. dropdown open 관련 상태
2. 로그아웃 로직
3. UI 렌더링
  - Refactor: 로그아웃 관련 로직을 Hooks로 분리하고 각자의 역할에 맞게 Component로 분리했습니다.
    - `hooks/useLogout.tsx` 로그아웃 관련 로직을 반환합니다.
    - `HeaderUserProfileNav.tsx`: 드롭다운의 open 관련 상태를 관리합니다.
    - `Dropdown/UserDropDown.tsx`: `isOpen` 과 `close` 함수를 `props`로 전달받아 내부적으로 `userState(Recoil)`에 접근하여DropDown UI를 반환합니다.

<br>

## ✅ 관심 리뷰
