### PR TITLE
Fix: 스터디 지원 시 query invalidates가 되지 않는 이슈 해결

### DIFF
--- a/src/components/common/join/JoinerCheck/JoinerCheck.tsx
+++ b/src/components/common/join/JoinerCheck/JoinerCheck.tsx
@@ -37,7 +37,6 @@ function JoinerCheck() {
     }
     setIsOpenJoinModal(true);
   };
-
   if (postDataStatus === 'loading') return <div>loading...</div>;
   if (postDataStatus === 'success' && applicantDataStatus === 'success')
     return (

--- a/src/components/common/join/Modal/JoinModal.tsx
+++ b/src/components/common/join/Modal/JoinModal.tsx
@@ -15,17 +15,16 @@ interface IJoinModalProps {
 export function JoinModal({ isOpen, setIsOpen, postId }: IJoinModalProps) {
   const useProfile = useRecoilValue(UserState);
   const [formData, setFormData] = useState('');
-  const { mutateAsync: addApplicantMutateAsync } = useUpdateApplicant(postId);
+  const { mutateAsync: addApplicantMutateAsync } = useUpdateApplicant(
+    Number(postId),
+  );
   const applyApplicationQuery = useDeleteApplicant(postId);
 
   const addApplicationOnClick = () => {
-    addApplicantMutateAsync(formData).then((response) => {
-      if (response.status === 200) {
+    addApplicantMutateAsync(formData, {
+      onSuccess: () => {
         setIsOpen((pre) => !pre);
-        alert('지원을 성공했어요.');
-        return;
-      }
-      return alert('지원에 실패했어요.');
+      },
     });
   };
   const onChangeByTextarea = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/hooks/useMutateQuery.tsx
+++ b/src/hooks/useMutateQuery.tsx
@@ -107,12 +107,19 @@ export const useUpdateAlarm = (notificationId: string) => {
   });
 };
 
-export const useUpdateApplicant = (postId: string | undefined) => {
+export const useUpdateApplicant = (postId: number | undefined) => {
   const queryClient = useQueryClient();
   return useMutation(
     (message: string) => ApplicationAPI.postApplicant(postId, message),
     {
-      onSuccess: () => queryClient.invalidateQueries(['applicant', postId]),
+      onSuccess: () => {
+        alert('지원을 성공했어요.');
+        return queryClient.invalidateQueries(['applicant', postId]);
+      },
+      onError: () => {
+        alert('지원에 실패했어요.');
+        return queryClient.invalidateQueries(['applicant', postId]);
+      },
     },
   );
 };


### PR DESCRIPTION
## Description
스터디 지원이 성공,실패 했을 때 현재 지원자의 수가 최신화 되지 않는 이슈를 해결하였습니다.
## 📌 전반적인 개발 내용 
useQuery를 반환하는 hooks에서 queryClient.invalidates를 콜백함수로 호출하여 refetch가 일어나도록 하였으며 클라이언트 상태를 변경하는 함수는 컴포넌트에서 호출하도록 하였습니다.
<br>

## 💻 변경 내용
- custom useQueryHooks에서  스터디 지원 요청을 성공, 실패 했을 때 호출되는 콜백함수를 선언해주었습니다.

- 컴포넌트에서 mutate를 호출할 때 onSuccess의 콜백함수를 추가하여 모달을 close하도록 하였습니다.

- **In Progress: 하나의 queryKeys 객체를 통해 메서드로 queryKey를 반환받도록 수정중에 있습니다.**
<br>

## ✅ 관심 리뷰
