### PR TITLE
Refactor: queryKeys의 메서드로 필요한 queryKey를 받아오도록 변경

### DIFF
--- a/src/components/atoms/SkillIcon/SkillIcon.tsx
+++ b/src/components/atoms/SkillIcon/SkillIcon.tsx
@@ -3,12 +3,13 @@ import icon from '@components/common/svg';
 import classes from './SkillIcon.module.scss';
 interface Props {
   className?: string;
+  alt?: string;
   src: string;
 }
-export const SkillIcon = ({ className, src }: Props) => {
+export const SkillIcon = ({ className, src, alt }: Props) => {
   return (
     <li className={[classes.default, className].join(' ')}>
-      <img src={icon[src] || src} alt="icon" />
+      <img src={icon[src] || src} alt={!alt ? 'icon' : alt} />
     </li>
   );
 };

--- a/src/components/common/main/StudySection/StudySection.tsx
+++ b/src/components/common/main/StudySection/StudySection.tsx
@@ -2,13 +2,14 @@ import { PostAPI } from '@api/api';
 import { SectionTitle, SelectItem } from '@components/atoms';
 import { Carousel } from '@components/common';
 import { NewPostCard } from '@components/common/post/PostCard/NewPostCard';
-import { PostCard } from '@components/common/post/PostCard/PostCard';
+// import { PostCard } from '@components/common/post/PostCard/PostCard';
 import { IResponsePostDetail } from '@components/pages/DetailPage/NewDetailPage';
+import { queryKeys } from '@hooks/query';
 import { useInfiniteQueryTest } from '@hooks/useInfiniteQueryTest';
 import { useEffect, useRef, useState } from 'react';
 import { useQueryClient } from 'react-query';
 import { useSearchParams } from 'react-router-dom';
-import type { IPostType } from 'types/post.types';
+// import type { IPostType } from 'types/post.types';
 import classes from './studySection.module.scss';
 import './studySection.scss';
 // 처음 studySection 이 mount될때 비동기적으로 server에 limit 16으로 받아오고
@@ -29,7 +30,7 @@ export function StudySection() {
 
   const { data, fetchNextPage, status } = useInfiniteQueryTest({
     getData: PostAPI.getPostList,
-    queryKey: 'test',
+    queryKey: queryKeys.postsAll,
     responseKeys: ['body', 'data'],
     pageSize: 4,
   });

--- a/src/components/common/post/PostList/PostList.tsx
+++ b/src/components/common/post/PostList/PostList.tsx
@@ -14,7 +14,6 @@ import { PostCard } from '../PostCard/PostCard';
 import { IPostType } from 'types/post.types';
 import classes from './postList.module.scss';
 
-
 const container = {
   hidden: { opacity: 0 },
   show: {
@@ -54,7 +53,7 @@ export function PostList() {
   useEffect(() => {
     if (searchResult && searchResult.data) {
       setPosts([...searchResult.data]);
-      handleCategory([...searchResult.data]); 
+      handleCategory([...searchResult.data]);
     } else {
       if (data?.result?.content) {
         setPosts([...data.result.content]);
@@ -125,44 +124,48 @@ export function PostList() {
     <>
       <div className={classes.postListContainer}>
         <div className={classes.postListContainerHeader}>
-          <SectionTitle title={'커리어 성장을 위한 스터디'} sub={"Level Up Study"} description={"커리어 성장을 위한 스터디를 찾으시나요? 토티에는 이런저런 여러분야의 스터디가 모여있어요."}/>
+          <SectionTitle
+            title={'커리어 성장을 위한 스터디'}
+            sub={'Level Up Study'}
+            description={
+              '커리어 성장을 위한 스터디를 찾으시나요? 토티에는 이런저런 여러분야의 스터디가 모여있어요.'
+            }
+          />
           <ul className={classes.filterList}>
-              {['최신순', '댓글많은순', '좋아요순'].map(
-                (item: string, idx: number) => (
-                  <li
-                    onClick={() =>
-                      setSearchParams({
-                        ...Object.fromEntries(searchParams),
-                        ['filter']: item,
-                      })
-                    }
-                    className={
-                      selectedFilter === item ? classes.selected : ''
-                    }
-                    key={`filter-${idx}`}
-                  >
-                    <span className={classes.tag_wrapper}>
-                      <div className={classes.outer_circle}>
-                        <div className={classes.inner_circle}></div>
-                      </div>
-                      #{item}
-                    </span>
-                  </li>
-                ),
-              )}
-            </ul>
+            {['최신순', '댓글많은순', '좋아요순'].map(
+              (item: string, idx: number) => (
+                <li
+                  onClick={() =>
+                    setSearchParams({
+                      ...Object.fromEntries(searchParams),
+                      ['filter']: item,
+                    })
+                  }
+                  className={selectedFilter === item ? classes.selected : ''}
+                  key={`filter-${idx}`}
+                >
+                  <span className={classes.tag_wrapper}>
+                    <div className={classes.outer_circle}>
+                      <div className={classes.inner_circle}></div>
+                    </div>
+                    #{item}
+                  </span>
+                </li>
+              ),
+            )}
+          </ul>
         </div>
         <motion.ul initial="hidden" animate="show" variants={container}>
           <div>
             <SectionSlider>
-            {postsFiltered &&
-              postsFiltered.length > 0 &&
-              postsFiltered
-                .slice(0, isShowTotal ? postsFiltered.length : 8)
-                .map((post: IPostType, idx: number) => (
-                  <PostCard key={`postCard-${idx}`} post={post} />
-                ))}
-          </SectionSlider>
+              {postsFiltered &&
+                postsFiltered.length > 0 &&
+                postsFiltered
+                  .slice(0, isShowTotal ? postsFiltered.length : 8)
+                  .map((post: IPostType, idx: number) => (
+                    <PostCard key={`postCard-${idx}`} post={post} />
+                  ))}
+            </SectionSlider>
           </div>
           <ObservationComponent />
         </motion.ul>

--- a/src/components/domain/SkillSelector.tsx
+++ b/src/components/domain/SkillSelector.tsx
@@ -3,6 +3,7 @@ import { Circle } from '@components/ui/circle/Circle';
 import { MouseEvent, ReactNode, useEffect, useState } from 'react';
 import classes from './skillSelector.module.scss';
 import icon from '@components/common/svg';
+import { SkillIcon } from '@components/atoms/SkillIcon/SkillIcon';
 
 export type stringKeyStringListValueType = { [key: string]: string[] };
 export type stringKeyBooleanValueType = { [key: string]: boolean };
@@ -10,14 +11,14 @@ export type stringKeyBooleanValueType = { [key: string]: boolean };
 // TODO: hooks로 분리할 예정입니다.
 
 const skillList: stringKeyStringListValueType = {
-  프론트엔드: ['JavaScript', 'Nextjs', 'React', 'Svelte', 'typescript'],
+  프론트엔드: ['JavaScript', 'Nextjs', 'React', 'Svelte', 'TypeScript'],
   백엔드: [
     'Django',
     'Express',
     'Firebase',
     'Go',
     'GraphQL',
-    'JAVA',
+    'Java',
     'Kotlin',
     'MongoDB',
     'MySQL',
@@ -208,13 +209,16 @@ const SkillItem = ({ dataValue, isSelect, src, onClick }: SkillItemProps) => {
               alignItems: 'center',
             }}
           >
-            <img
-              style={{
-                objectPosition: '0px 5px',
-              }}
+            <SkillIcon src={src} alt={dataValue} />
+            {/* <img
+              style={
+                {
+                  // objectPosition: '0px 5px',
+                }
+              }
               src={src}
               alt={dataValue}
-            />
+            /> */}
             <div>{dataValue}</div>
           </div>
         </div>

--- a/src/components/pages/DetailPage/DetailPage.tsx
+++ b/src/components/pages/DetailPage/DetailPage.tsx
@@ -23,11 +23,9 @@ import { useUpdateLike } from '@hooks/useMutateQuery';
 function DetailPage() {
   const navigate = useNavigate();
   let { id } = useParams();
-  const { data: postData, refetch } = useGetPostByPostId(
-    parseInt(id as string),
-  );
-  const { data: likeData } = useGetLikeofPost(id as string);
-  const LikeUpdateMutation = useUpdateLike(id as string);
+  const { data: postData, refetch } = useGetPostByPostId(Number(id));
+  const { data: likeData } = useGetLikeofPost(Number(id));
+  const LikeUpdateMutation = useUpdateLike(Number(id));
 
   const [detailData, setDetailData] = useState<any>([]);
   const [Like, setLike] = useState<any>(false);

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,0 +1,16 @@
+export const queryKeys = {
+  user: ['user'],
+  postsAll: ['postAll'],
+  post: (postId: number) => ['post', postId],
+  applicant: (postId: number) => ['applicant', postId],
+  searchTitle: (postTitle: string) => ['search', postTitle],
+  categories: ['categories'],
+  recommend: ['recommend'],
+  likePost: (postId: number) => ['like', postId],
+  alarms: ['alarms'],
+  // 구현 전
+  // team: (postId: number) => ['team', postId],
+};
+
+// get 완료
+// mutate 완료

--- a/src/hooks/useGetQuery.tsx
+++ b/src/hooks/useGetQuery.tsx
@@ -9,29 +9,34 @@ import {
 } from '@api/api';
 import { useRecoilState } from 'recoil';
 import { UserState } from '@store/user';
+import { queryKeys } from './query';
 
 export function useGetUserAPI() {
   const [user, setUser] = useRecoilState(UserState);
 
-  return useQuery(['user'], () => UserAPI.getUserInfo().catch((err) => err), {
-    // 브라우저 focus 됐을 때 재시작?
-    retry: false,
-    refetchOnWindowFocus: false,
-    // 자동으로 가져오는 옵션
-    enabled: true,
-    // 캐시 타임
-    staleTime: 10 * 600 * 1000,
-    onSuccess: (res) => {
-      if (res?.data?.body.data) {
-        setUser(res.data.body.data);
-      }
+  return useQuery(
+    queryKeys.user,
+    () => UserAPI.getUserInfo().catch((err) => err),
+    {
+      // 브라우저 focus 됐을 때 재시작?
+      retry: false,
+      refetchOnWindowFocus: false,
+      // 자동으로 가져오는 옵션
+      enabled: true,
+      // 캐시 타임
+      staleTime: 10 * 600 * 1000,
+      onSuccess: (res) => {
+        if (res?.data?.body.data) {
+          setUser(res.data.body.data);
+        }
+      },
     },
-  });
+  );
 }
 
 export function useGetPostListAPI() {
   return useQuery(
-    ['postsAll'],
+    queryKeys.postsAll,
     () => PostAPI.getPostList().catch((err) => err),
     {
       // 브라우저 focus 됐을 때 재시작?
@@ -46,20 +51,24 @@ export function useGetPostListAPI() {
 }
 
 export function useGetPostByPostId(postId: number) {
-  return useQuery(['post', postId], () => PostAPI.getPostByPostId(postId), {
-    // 브라우저 focus 됐을 때 재시작?
-    retry: false,
-    refetchOnWindowFocus: true,
-    // 자동으로 가져오는 옵션
-    enabled: true,
-    // 캐시 타임
-    staleTime: 10 * 600 * 1000,
-  });
+  return useQuery(
+    queryKeys.post(postId),
+    () => PostAPI.getPostByPostId(postId),
+    {
+      // 브라우저 focus 됐을 때 재시작?
+      retry: false,
+      refetchOnWindowFocus: true,
+      // 자동으로 가져오는 옵션
+      enabled: true,
+      // 캐시 타임
+      staleTime: 10 * 600 * 1000,
+    },
+  );
 }
 
 export function useGetSearchPostList(title: string) {
   return useQuery(
-    ['search', title],
+    queryKeys.searchTitle(title),
     () => title.length > 0 && PostAPI.searchPostList(title).catch((err) => err),
     {
       // 브라우저 focus 됐을 때 재시작?
@@ -75,7 +84,7 @@ export function useGetSearchPostList(title: string) {
 
 export function useGetCategoryList() {
   return useQuery(
-    ['categories'],
+    queryKeys.categories,
     () => CategoryAPI.getCategoryList().catch((err) => err),
     {
       // 브라우저 focus 됐을 때 재시작?
@@ -90,7 +99,7 @@ export function useGetCategoryList() {
 }
 
 export function useGetRecommendList() {
-  return useQuery(['recommend'], () => PostAPI.recommendPostList(), {
+  return useQuery(queryKeys.recommend, () => PostAPI.recommendPostList(), {
     // 브라우저 focus 됐을 때 재시작?
     retry: false,
     refetchOnWindowFocus: false,
@@ -101,20 +110,24 @@ export function useGetRecommendList() {
   });
 }
 
-export function useGetLikeofPost(postId: string | number) {
-  return useQuery(['like', postId], () => LikeAPI.getIsLikeInfo(postId), {
-    // 브라우저 focus 됐을 때 재시작?
-    retry: false,
-    refetchOnWindowFocus: false,
-    // 자동으로 가져오는 옵션
-    enabled: true,
-    // 캐시 타임
-    staleTime: 10 * 600 * 1000,
-  });
+export function useGetLikeofPost(postId: number) {
+  return useQuery(
+    queryKeys.likePost(postId),
+    () => LikeAPI.getIsLikeInfo(postId),
+    {
+      // 브라우저 focus 됐을 때 재시작?
+      retry: false,
+      refetchOnWindowFocus: false,
+      // 자동으로 가져오는 옵션
+      enabled: true,
+      // 캐시 타임
+      staleTime: 10 * 600 * 1000,
+    },
+  );
 }
 
 export function useGetAlarm() {
-  return useQuery(['alarms'], () => AlarmAPI.getAlarm(), {
+  return useQuery(queryKeys.alarms, () => AlarmAPI.getAlarm(), {
     retry: false,
     refetchOnWindowFocus: true,
     enabled: true,
@@ -124,7 +137,7 @@ export function useGetAlarm() {
 
 export function useGetApplicant(postId: number) {
   return useQuery(
-    ['applicant', postId],
+    queryKeys.applicant(postId),
     () => ApplicationAPI.getApplicant(postId),
     {
       retry: false,

--- a/src/hooks/useInfiniteQueryTest.tsx
+++ b/src/hooks/useInfiniteQueryTest.tsx
@@ -14,8 +14,6 @@ export const useInfiniteQueryTest = ({
   pageSize,
   responseKeys,
 }: Props) => {
-  // const [returnPageParam, setReturnPageParam] = useState(0);
-
   const getPageInfo = async ({ pageParam = 0 }) => {
     // setReturnPageParam(pageParam);
     const response = await getData(pageParam, pageSize);

--- a/src/hooks/useMutateQuery.tsx
+++ b/src/hooks/useMutateQuery.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, useMutation, useQuery } from 'react-query';
+import { useMutation } from 'react-query';
 import {
   AlarmAPI,
   ApplicationAPI,
@@ -11,6 +11,7 @@ import {
 } from '@api/api';
 import { useQueryClient } from 'react-query';
 import { IPostTeamRequestFormData } from '@api/requestType';
+import { queryKeys } from './query';
 export interface IReplyRequest {
   commentId: number;
   content: string;
@@ -19,28 +20,28 @@ export interface IReplyRequest {
 export const useAddUserInfo = () => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => UserAPI.addUserInfo(form), {
-    onSuccess: () => queryClient.invalidateQueries('user'),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.user),
   });
 };
 
 export const useAddComment = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => CommentAPI.createComment(form), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
   });
 };
 
 export const useUpdateComment = (postId: number, commentId: number) => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => CommentAPI.updateComment(commentId, form), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
   });
 };
 
 export const useDeleteComment = (postId: number, commentId: number) => {
   const queryClient = useQueryClient();
   return useMutation(() => CommentAPI.deleteComment(commentId), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
     onError: () => {
       throw new Error(`
       에러가 지속될 경우 해당 이메일로 문의해주세요.
@@ -54,7 +55,7 @@ export const useAddReply = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation((form: IReplyRequest) => ReplyAPI.createReply(form), {
     onSuccess: () => {
-      queryClient.invalidateQueries(['post', postId]);
+      queryClient.invalidateQueries(queryKeys.post(postId));
     },
   });
 };
@@ -62,14 +63,14 @@ export const useAddReply = (postId: number) => {
 export const useUpdateReply = (postId: number, replyId: number) => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => ReplyAPI.updateReply(replyId, form), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
   });
 };
 
 export const useDeleteReply = (postId: number, replyId: number) => {
   const queryClient = useQueryClient();
   return useMutation(() => ReplyAPI.deleteReply(replyId), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
   });
 };
 
@@ -77,7 +78,7 @@ export const useUpdatePostStatus = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation(() => PostAPI.statusChange(postId), {
     onSuccess: () => {
-      queryClient.invalidateQueries(['post', postId]);
+      queryClient.invalidateQueries(queryKeys.post(postId));
     },
   });
 };
@@ -85,17 +86,17 @@ export const useUpdatePostStatus = (postId: number) => {
 export const useUpdateUser = () => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => UserAPI.updateUserInfo(form), {
-    onSuccess: () => queryClient.invalidateQueries('user'),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.user),
   });
 };
 
-export const useUpdateLike = (postId: string | number) => {
+export const useUpdateLike = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation((postId: any) => LikeAPI.postLike(postId), {
     onSuccess: () => {
       queryClient.invalidateQueries('posts');
-      queryClient.invalidateQueries(['post', postId]);
-      queryClient.invalidateQueries(['like', postId]);
+      queryClient.invalidateQueries(queryKeys.post(postId));
+      queryClient.invalidateQueries(queryKeys.likePost(postId));
     },
   });
 };
@@ -103,22 +104,22 @@ export const useUpdateLike = (postId: string | number) => {
 export const useUpdateAlarm = (notificationId: string) => {
   const queryClient = useQueryClient();
   return useMutation(() => AlarmAPI.updateAlarm(notificationId), {
-    onSuccess: () => queryClient.invalidateQueries('alarms'),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.alarms),
   });
 };
 
-export const useUpdateApplicant = (postId: number | undefined) => {
+export const useUpdateApplicant = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation(
     (message: string) => ApplicationAPI.postApplicant(postId, message),
     {
       onSuccess: () => {
         alert('지원을 성공했어요.');
-        return queryClient.invalidateQueries(['applicant', postId]);
+        return queryClient.invalidateQueries(queryKeys.applicant(postId));
       },
       onError: () => {
         alert('지원에 실패했어요.');
-        return queryClient.invalidateQueries(['applicant', postId]);
+        return queryClient.invalidateQueries(queryKeys.applicant(postId));
       },
     },
   );

--- a/src/hooks/usePostQuery.tsx
+++ b/src/hooks/usePostQuery.tsx
@@ -1,6 +1,7 @@
 import { useMutation } from 'react-query';
 import { PostAPI, UserAPI } from '@api/api';
 import { useQueryClient } from 'react-query';
+import { queryKeys } from './query';
 
 // export const useAddPost = () => {
 //   const queryClient = useQueryClient();
@@ -14,10 +15,9 @@ import { useQueryClient } from 'react-query';
 //   return data;
 // };
 
+// post
 export const useAddPost = (postAPI: (data: any) => Promise<any>) => {
-  return useMutation((data: any) => postAPI(data), {
-    // onSuccess: () => ('salertuccess'),
-  });
+  return useMutation((data: any) => postAPI(data));
 };
 // export const useAddPost = (postForm: (data?: any): Promise<any> => {} )=> {
 //   return useMutation(postForm, {
@@ -28,13 +28,12 @@ export const useAddPost = (postAPI: (data: any) => Promise<any>) => {
 export const useUpdatePost = (postId: number) => {
   const queryClient = useQueryClient();
   return useMutation((form: any) => PostAPI.upDatePost(postId, form), {
-    onSuccess: () => queryClient.invalidateQueries(['post', postId]),
+    onSuccess: () => queryClient.invalidateQueries(queryKeys.post(postId)),
   });
 };
 
+// redirect 해주기 때문에 invalidateQueries해줄 필요 없다.
+// 또한 redirect하기 전에 데이터를 지워버려 refetch가 일어나게 되면 url은 그대로인데 데이터만 없어 에러가 발생한다.
 export const useDeletePost = (postId: number) => {
-  const queryClient = useQueryClient();
-  return useMutation(() => PostAPI.deletePost(postId), {
-    // queryClient에서 ['post', postId]를 component에서 업데이트가 일어날 때 query를 지워버려 error가 뜬다.
-  });
+  return useMutation(() => PostAPI.deletePost(postId), {});
 };

--- a/src/hooks/useProfileImage.tsx
+++ b/src/hooks/useProfileImage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+// 🟠 hooks라기 보다는 로직을 가지고 있는 component에 가깝다.
 import removeImg from '../assets/svg/removeImg.svg';
 import changeImg from '../assets/svg/changeImg.svg';
 


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용
Refactor: `queryKeys`의 메서드로 필요한 queryKey를 받아오도록 변경

<br>

## 💻 변경 내용
- add: queryKey를 메서드, 프로퍼티로 가지고 있는 `queryKeys` 객체 추가
- refactor: `useQuery`의 queryKey를 하드코딩에서 객체의 메서드를 통해 받아오도록 변경
- refactor: `useMutate`의 options 내부에서 `queryClient.invalidateQueries`에서 queryKey를 `queryKeys` 객체에서 받아오도록 변경
- fix: skillSelector에서 이미지 경로를 받아오기 위한 배열의 문자열이 잘못되어 있는 부분 수정 ('typescript' => 'TypeScript')

<br>

## ✅ 관심 리뷰
