### PR TITLE
Feat/i126 all post

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
   MyPage,
   NewDetailPage,
   NotMatchPage,
+  PostsPage,
 } from 'pages';
 import { ScrollTopButton } from '@components/atoms';
 import { Banner, Footer, Header } from '@components/common';
@@ -25,7 +26,7 @@ import './App.css';
 
 const isNotLoginRoutes = [
   { path: '/', element: <MainPage /> },
-  // { path: '/posts', element: <PostsPage /> },
+  { path: '/posts', element: <PostsPage /> },
   { path: '/oauth/redirect', element: <LoginOauth /> },
   { path: '/detail/:id', element: <NewDetailPage /> },
 ];

--- a/src/api/api.tsx
+++ b/src/api/api.tsx
@@ -36,8 +36,13 @@ export const PostAPI = {
   getPostList: (
     page = 0,
     size = 5,
-  ): Promise<AxiosResponse<IGetPostListResponse>> =>
-    api.get(`/api/v1/post/list?page=${page}&size=${size}`),
+    filter?: string,
+  ): Promise<AxiosResponse<IGetPostListResponse>> => {
+    if (!filter) return api.get(`/api/v1/post/list?page=${page}&size=${size}`);
+    return api.get(
+      `/api/v1/post/list?page=${page}&size=${size}&sort=${filter},desc`,
+    );
+  },
   getPostByPostId: (
     postId: number,
   ): Promise<AxiosResponse<IGetPostDetailResponse>> =>

--- a/src/components/atoms/Circle/Circle.tsx
+++ b/src/components/atoms/Circle/Circle.tsx
@@ -3,12 +3,33 @@ import type { ButtonHTMLAttributes } from 'react';
 interface Props extends ButtonHTMLAttributes<HTMLDivElement> {
   selected: boolean;
   backgroundColor?: string;
+  options?: {
+    outCircle: boolean;
+  };
 }
 
 import classes from './circle.module.scss';
 
 // background color를 넘겨줄 경우 인라인으로 덮어씌워준다
-export const Circle = ({ selected = false, backgroundColor }: Props) => {
+export const Circle = ({
+  selected = false,
+  backgroundColor,
+  options = { outCircle: true },
+}: Props) => {
+  if (!options.outCircle) {
+    return (
+      <div className={classes.non_outer_circle}>
+        <div
+          className={
+            selected
+              ? classes.inner_circle + ' ' + classes.select
+              : classes.inner_circle
+          }
+          style={{ backgroundColor: selected ? backgroundColor : '' }}
+        ></div>
+      </div>
+    );
+  }
   return (
     <div className={classes.outer_circle}>
       <div

--- a/src/components/atoms/Circle/circle.module.scss
+++ b/src/components/atoms/Circle/circle.module.scss
@@ -8,7 +8,6 @@
   border-radius: 100%;
   background-color: #ffffff;
   border: 1px solid #222222;
-
   .inner_circle {
     width: 10px;
     height: 10px;
@@ -18,5 +17,22 @@
 
   .select {
     background-color: #ffd02c;
+  }
+}
+
+.non_outer_circle {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  .inner_circle {
+    width: 10px;
+    height: 10px;
+    margin-right: 7px;
+    border-radius: 100%;
+    background-color: #a0aec0;
+  }
+
+  .select {
+    background-color: #568a35;
   }
 }

--- a/src/components/atoms/SectionTitle/SectionTitle.tsx
+++ b/src/components/atoms/SectionTitle/SectionTitle.tsx
@@ -6,9 +6,9 @@ interface Props {
   title: string;
   sub: string;
   description: string;
-  onClickTotal?: () => {};
+  onClick?: () => void;
 }
-export function SectionTitle({ title, sub, description, onClickTotal }: Props) {
+export function SectionTitle({ title, sub, description, onClick }: Props) {
   return (
     <div className={classes.title_wrapper}>
       <div>
@@ -16,7 +16,7 @@ export function SectionTitle({ title, sub, description, onClickTotal }: Props) {
         <h2 className={classes.title_main}>{title}</h2>
         <div className={classes.title_description}>{description}</div>
       </div>
-      <div className={classes.total_button_wrapper}>
+      <div className={classes.total_button_wrapper} onClick={onClick}>
         <div className={classes.button_desc}>전체 보기</div>
         <ChevronIcon />
       </div>

--- a/src/components/atoms/SkillIcon/SkillIcon.tsx
+++ b/src/components/atoms/SkillIcon/SkillIcon.tsx
@@ -7,8 +7,8 @@ interface Props {
 }
 export const SkillIcon = ({ className, src, alt }: Props) => {
   return (
-    <li className={[classes.default, className].join(' ')}>
+    <div className={[classes.default, className].join(' ')}>
       <img src={icon[src] || src} alt={!alt ? 'icon' : alt} />
-    </li>
+    </div>
   );
 };

--- a/src/components/atoms/SkillIcon/SkillIcons.tsx
+++ b/src/components/atoms/SkillIcon/SkillIcons.tsx
@@ -14,10 +14,7 @@ export const OverLimitIcons = ({
       {list
         .filter((value, index) => index < limit)
         .map((src, index) => (
-          <li
-            className={classes.default_skillIcons_over_wrap}
-            key={src + index}
-          >
+          <li className={classes.default_skillIcons_over_wrap} key={src}>
             <div className={classes.default_skillIcons_cover}>
               <SkillIcon key={src + index} src={src} alt="skill_icon" />
             </div>

--- a/src/components/atoms/svg/index.ts
+++ b/src/components/atoms/svg/index.ts
@@ -1,3 +1,5 @@
+// component라기 보다는 constant로 가는게 좋을 것 같다.
+
 import JavaScript from '@assets/svg/skills/frontEnd/JavaScript.svg';
 import Nextjs from '@assets/svg/skills/frontEnd/Nextjs.svg';
 import React from '@assets/svg/skills/frontEnd/React.svg';

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -19,5 +19,6 @@ export * from './detail/Select/Select';
 export * from './selector/SkillSelector';
 
 export * from './section/MentorReviewSection/MentorReviewSection';
+export * from './section/SearchSection';
 
 export * from './main/SectionSlider/SectionSlider';

--- a/src/components/common/join/OwnerJoinerCheck/OwnerJoinerCheck.tsx
+++ b/src/components/common/join/OwnerJoinerCheck/OwnerJoinerCheck.tsx
@@ -55,26 +55,6 @@ function OwnerJoinerCheck() {
                 <div className="StatusM_Name">{applicant.nickname}</div>
               </div>
             ))}
-            <div className="StatusM_NameBox">
-              <div className="StatusM_ProfileImg" />
-              <div className="StatusM_Name">dummy data</div>
-            </div>
-            <div className="StatusM_NameBox">
-              <div className="StatusM_ProfileImg" />
-              <div className="StatusM_Name">dummy data</div>
-            </div>
-            <div className="StatusM_NameBox">
-              <div className="StatusM_ProfileImg" />
-              <div className="StatusM_Name">dummy data</div>
-            </div>
-            <div className="StatusM_NameBox">
-              <div className="StatusM_ProfileImg" />
-              <div className="StatusM_Name">dummy data</div>
-            </div>
-            <div className="StatusM_NameBox">
-              <div className="StatusM_ProfileImg" />
-              <div className="StatusM_Name">dummy data</div>
-            </div>
           </div>
           <button
             className="StatusM_Btn"

--- a/src/components/common/main/StudySection/StudySection.tsx
+++ b/src/components/common/main/StudySection/StudySection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useQueryClient } from 'react-query';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 import { PostAPI } from '@api/api';
@@ -17,10 +17,11 @@ import './studySection.scss';
 const filterList = ['전체', '최신순', '인기순', '조회순'];
 
 export function StudySection() {
+  const navigate = useNavigate();
+
   const [filteredPageList, setFilteredPageList] = useState<
     IResponsePostDetail[][]
   >([]);
-
   const [selectedFilter, setSelectedFilter] = useState(filterList[0]);
   // urldml params를 읽고 수정할 수 있다.
   const [searchParams, setSearchParams] = useSearchParams();
@@ -28,11 +29,14 @@ export function StudySection() {
 
   const { data, fetchNextPage, status } = useInfiniteQueryTest({
     getData: PostAPI.getPostList,
-    queryKey: queryKeys.postsAll,
+    queryKey: queryKeys.postsSlider,
     responseKeys: ['body', 'data'],
     pageSize: 4,
   });
 
+  const onClickWithNavigate = () => {
+    navigate('/posts');
+  };
   useEffect(() => {
     return () => {
       setFilteredPageList([]);
@@ -113,6 +117,7 @@ export function StudySection() {
             title={'커리어 성장을 위한 스터디'}
             sub={'Level Up Study'}
             description={`커리어 성장을 위한 스터디를 찾으시나요?\n토티에는 이런저런 여러분야의 스터디가 모여있어요.`}
+            onClick={onClickWithNavigate}
           />
         </div>
         <SectionFilter filterList={filterList} />

--- a/src/components/common/post/PostCard/PostCard.tsx
+++ b/src/components/common/post/PostCard/PostCard.tsx
@@ -50,7 +50,6 @@ export const NewPostCard = ({ post }: OptionalProps) => {
     </div>
   );
 };
-// };
 
 const NewPostCardHeader = ({ post }: NewPostCardProps) => {
   return (

--- a/src/components/common/section/SearchSection/SearchSection.module.scss
+++ b/src/components/common/section/SearchSection/SearchSection.module.scss
@@ -1,0 +1,3 @@
+.searchSection {
+  padding: 30px 0 65px 0;
+}

--- a/src/components/common/section/SearchSection/index.tsx
+++ b/src/components/common/section/SearchSection/index.tsx
@@ -1,0 +1,10 @@
+import { Search } from '@components/common/main/Search/Search';
+import classes from './SearchSection.module.scss';
+
+export const SearchSection = () => {
+  return (
+    <section className={classes.searchSection}>
+      <Search />
+    </section>
+  );
+};

--- a/src/components/domains/posts/PostsFilter/index.tsx
+++ b/src/components/domains/posts/PostsFilter/index.tsx
@@ -1,9 +1,8 @@
-import { Dispatch, ReactNode, SetStateAction, useEffect } from 'react';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Circle } from '@components/atoms';
 import { IResponsePostDetail } from 'types/api.types';
-// import { useSort } from '@hooks/useSort';
 import classes from './postsFilter.module.scss';
 import { ISortOptions, sortOptionNameType } from 'types/sort.types';
 

--- a/src/components/domains/posts/PostsFilter/index.tsx
+++ b/src/components/domains/posts/PostsFilter/index.tsx
@@ -3,39 +3,29 @@ import { useSearchParams } from 'react-router-dom';
 
 import { Circle } from '@components/atoms';
 import { IResponsePostDetail } from 'types/api.types';
-import { useSort } from '@hooks/useSort';
+// import { useSort } from '@hooks/useSort';
 import classes from './postsFilter.module.scss';
+import { ISortOptions, sortOptionNameType } from 'types/sort.types';
 
 interface Props {
-  datas: IResponsePostDetail[];
-  setDatas: Dispatch<SetStateAction<any>>;
+  datas?: IResponsePostDetail[];
+  setDatas?: Dispatch<SetStateAction<any>>;
   options: ISortOptions;
   element?: ReactNode;
 }
 
-// 이걸 객체로 받아서 key로 함수를 판단하고 value로 버튼의 text를 판단한다.
-interface ISortOptions {
-  [key: string]: string;
-}
-// 'recent' | 'comment' | 'like' | 'view'
-
 export const PostsFilter = ({ datas, setDatas, options, element }: Props) => {
-  const { sortedDatas, setSortFunctions } = useSort(datas);
   const [searchParams, setSearchParams] = useSearchParams();
-  useEffect(() => {
-    setDatas(sortedDatas);
-  }, [sortedDatas]);
 
-  // Todo: onClick도 useSort로 뺄 수 있지 않을까?
-  const onClick = (key: string) => {
+  const onClick = (key: sortOptionNameType) => {
     setSearchParams({ filter: key });
-    setSortFunctions[key];
   };
 
-  // 🟠 Todo: inlineStyle을 SCSS로 변경 예정
+  const filterList = Object.entries(options) as [sortOptionNameType, string][];
+
   return (
     <ul className={classes.filters}>
-      {Object.entries(options).map(([key, value]) => (
+      {filterList.map(([key, value]) => (
         <li key={key} className={classes.filter} onClick={() => onClick(key)}>
           <Circle
             selected={searchParams.get('filter') === key}

--- a/src/components/domains/posts/PostsFilter/index.tsx
+++ b/src/components/domains/posts/PostsFilter/index.tsx
@@ -1,0 +1,123 @@
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { Circle } from '@components/atoms';
+import { IResponsePostDetail } from 'types/api.types';
+import classes from './postsFilter.module.scss';
+
+interface Props {
+  datas: IResponsePostDetail[];
+  setDatas: Dispatch<SetStateAction<any>>;
+  options: ISortOptions;
+  element?: ReactNode;
+}
+
+// 이걸 객체로 받아서 key로 함수를 판단하고 value로 버튼의 text를 판단한다.
+interface ISortOptions {
+  [key: string]: string;
+}
+// 'recent' | 'comment' | 'like' | 'view'
+
+export const PostsFilter = ({ datas, setDatas, options, element }: Props) => {
+  const { sortedDatas, setSortFunctions } = useSort(datas);
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    setDatas(sortedDatas);
+  }, [sortedDatas]);
+
+  // Todo: onClick도 useSort로 뺄 수 있지 않을까?
+  const onClick = (key: string) => {
+    setSearchParams({ filter: key });
+    setSortFunctions[key];
+  };
+
+  // 🟠 Todo: inlineStyle을 SCSS로 변경 예정
+  return (
+    <ul style={{ display: 'flex', gap: 10 }}>
+      {Object.entries(options).map(([key, value]) => (
+        <li
+          style={{ display: 'flex', cursor: 'pointer' }}
+          key={value}
+          onClick={() => onClick(key)}
+        >
+          <Circle
+            selected={searchParams.get('filter') === key}
+            options={{ outCircle: false }}
+          />
+          {value}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+type useSortPropsType = IResponsePostDetail[];
+
+// 🟠 Todo: hooks 폴더 내부로 이동시킬 예정
+export const useSort = (posts: useSortPropsType = []) => {
+  const [sortedDatas, setSortedDatas] = useState<any[]>(posts);
+
+  // posts를 직접적으로 호출해주지 않기 때문이 아닐까?
+  // 빈배열이 넘어오더라도 결국 component에서 data가 있을 때에만 해당 hooks를 호출해주도록 한다면 문제는 없을 것 같다.;
+
+  // setSortFunctions
+  const sortRecent = () => {
+    return [...posts].sort(
+      (left, right) =>
+        Number(new Date(right.createdAt)) - Number(new Date(left.createdAt)),
+    );
+  };
+  const sortCommentCount = () => {
+    return [...posts].sort((left, right) => right.commentNum - left.commentNum);
+  };
+  const sortLikeCount = () => {
+    return [...posts].sort((left, right) => right.likeNum - left.likeNum);
+  };
+  const sortViewCount = () => {
+    return [...posts].sort((left, right) => right.view - left.view);
+  };
+
+  // sortFunctions
+  const setSortRecent = () => {
+    const result = sortRecent();
+    setSortedDatas(result);
+  };
+  const setSortCommentCount = () => {
+    const result = sortCommentCount();
+    setSortedDatas(result);
+  };
+  const setSortLikeCount = () => {
+    const result = sortLikeCount();
+    setSortedDatas(result);
+  };
+  const setSortViewCount = () => {
+    const result = sortViewCount();
+    setSortedDatas(result);
+  };
+
+  const sortFunctions = {
+    recent: sortRecent,
+    comment: sortCommentCount,
+    like: sortLikeCount,
+    view: sortViewCount,
+  };
+
+  const setSortFunctions = {
+    recent: setSortRecent,
+    comment: setSortCommentCount,
+    like: setSortLikeCount,
+    view: setSortViewCount,
+  } as { [key: string]: () => void };
+
+  // setsortFunctions, sortFunctions, sortedDatas를 return 받는다.
+  // 값만 리턴받기를 원한다면 sortFuctions를 사용하면 되고 setState까지 원한다면 setSortFunctions를 사용하면 된다.
+  // 해당 컴포넌트에서 state를 필요로 할 경우에도 사용가능하고, 해당 컴포넌트에서 props setState를 전달받으면 부모의 state까지 변경해줄 수 있다.
+
+  return { sortedDatas, setSortedDatas, setSortFunctions, sortFunctions };
+};

--- a/src/components/domains/posts/PostsFilter/index.tsx
+++ b/src/components/domains/posts/PostsFilter/index.tsx
@@ -1,14 +1,9 @@
-import {
-  Dispatch,
-  ReactNode,
-  SetStateAction,
-  useEffect,
-  useState,
-} from 'react';
+import { Dispatch, ReactNode, SetStateAction, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { Circle } from '@components/atoms';
 import { IResponsePostDetail } from 'types/api.types';
+import { useSort } from '@hooks/useSort';
 import classes from './postsFilter.module.scss';
 
 interface Props {
@@ -39,13 +34,9 @@ export const PostsFilter = ({ datas, setDatas, options, element }: Props) => {
 
   // 🟠 Todo: inlineStyle을 SCSS로 변경 예정
   return (
-    <ul style={{ display: 'flex', gap: 10 }}>
+    <ul className={classes.filters}>
       {Object.entries(options).map(([key, value]) => (
-        <li
-          style={{ display: 'flex', cursor: 'pointer' }}
-          key={value}
-          onClick={() => onClick(key)}
-        >
+        <li key={key} className={classes.filter} onClick={() => onClick(key)}>
           <Circle
             selected={searchParams.get('filter') === key}
             options={{ outCircle: false }}
@@ -55,69 +46,4 @@ export const PostsFilter = ({ datas, setDatas, options, element }: Props) => {
       ))}
     </ul>
   );
-};
-
-type useSortPropsType = IResponsePostDetail[];
-
-// 🟠 Todo: hooks 폴더 내부로 이동시킬 예정
-export const useSort = (posts: useSortPropsType = []) => {
-  const [sortedDatas, setSortedDatas] = useState<any[]>(posts);
-
-  // posts를 직접적으로 호출해주지 않기 때문이 아닐까?
-  // 빈배열이 넘어오더라도 결국 component에서 data가 있을 때에만 해당 hooks를 호출해주도록 한다면 문제는 없을 것 같다.;
-
-  // setSortFunctions
-  const sortRecent = () => {
-    return [...posts].sort(
-      (left, right) =>
-        Number(new Date(right.createdAt)) - Number(new Date(left.createdAt)),
-    );
-  };
-  const sortCommentCount = () => {
-    return [...posts].sort((left, right) => right.commentNum - left.commentNum);
-  };
-  const sortLikeCount = () => {
-    return [...posts].sort((left, right) => right.likeNum - left.likeNum);
-  };
-  const sortViewCount = () => {
-    return [...posts].sort((left, right) => right.view - left.view);
-  };
-
-  // sortFunctions
-  const setSortRecent = () => {
-    const result = sortRecent();
-    setSortedDatas(result);
-  };
-  const setSortCommentCount = () => {
-    const result = sortCommentCount();
-    setSortedDatas(result);
-  };
-  const setSortLikeCount = () => {
-    const result = sortLikeCount();
-    setSortedDatas(result);
-  };
-  const setSortViewCount = () => {
-    const result = sortViewCount();
-    setSortedDatas(result);
-  };
-
-  const sortFunctions = {
-    recent: sortRecent,
-    comment: sortCommentCount,
-    like: sortLikeCount,
-    view: sortViewCount,
-  };
-
-  const setSortFunctions = {
-    recent: setSortRecent,
-    comment: setSortCommentCount,
-    like: setSortLikeCount,
-    view: setSortViewCount,
-  } as { [key: string]: () => void };
-
-  // setsortFunctions, sortFunctions, sortedDatas를 return 받는다.
-  // 값만 리턴받기를 원한다면 sortFuctions를 사용하면 되고 setState까지 원한다면 setSortFunctions를 사용하면 된다.
-  // 해당 컴포넌트에서 state를 필요로 할 경우에도 사용가능하고, 해당 컴포넌트에서 props setState를 전달받으면 부모의 state까지 변경해줄 수 있다.
-
-  return { sortedDatas, setSortedDatas, setSortFunctions, sortFunctions };
 };

--- a/src/components/domains/posts/PostsFilter/postsFilter.module.scss
+++ b/src/components/domains/posts/PostsFilter/postsFilter.module.scss
@@ -1,0 +1,8 @@
+.postsFilterWrap {
+  .filters {
+    display: flex;
+    align-items: flex-end;
+    .filter {
+    }
+  }
+}

--- a/src/components/domains/posts/PostsFilter/postsFilter.module.scss
+++ b/src/components/domains/posts/PostsFilter/postsFilter.module.scss
@@ -5,5 +5,6 @@
   .filter {
     display: flex;
     align-items: center;
+    cursor: pointer;
   }
 }

--- a/src/components/domains/posts/PostsFilter/postsFilter.module.scss
+++ b/src/components/domains/posts/PostsFilter/postsFilter.module.scss
@@ -1,8 +1,9 @@
-.postsFilterWrap {
-  .filters {
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  .filter {
     display: flex;
-    align-items: flex-end;
-    .filter {
-    }
+    align-items: center;
   }
 }

--- a/src/components/domains/posts/PostsFooter/index.tsx
+++ b/src/components/domains/posts/PostsFooter/index.tsx
@@ -1,0 +1,3 @@
+export const PostsFooter = () => {
+  return null;
+};

--- a/src/components/domains/posts/PostsHeader/PostsHeader.module.scss
+++ b/src/components/domains/posts/PostsHeader/PostsHeader.module.scss
@@ -1,0 +1,19 @@
+.postsFilterContainer {
+  width: 100%;
+
+  position: sticky;
+  top: 70px;
+  z-index: 5;
+  padding: 0 10%;
+  margin-bottom: 15px;
+  // border-bottom: 1px solid gray;
+  background-color: white;
+
+  .postsFilterWrap {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    height: 100px;
+    gap: 10px;
+  }
+}

--- a/src/components/domains/posts/PostsHeader/index.tsx
+++ b/src/components/domains/posts/PostsHeader/index.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from 'react-router-dom';
+
+import { Button } from '@components/atoms';
+import { PostsFilter } from '../PostsFilter';
+import classes from './PostsHeader.module.scss';
+
+export const PostsHeader = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className={classes.postsFilterContainer}>
+      <div className={classes.postsFilterWrap}>
+        <PostsFilter
+          // datas={totalPosts}
+          // setDatas={setTotalPosts}
+          options={{
+            recent: '최신순',
+            commentNum: '댓글순',
+            view: '조회순',
+            likeNum: '좋아요순',
+          }}
+          // element={undefined}
+        />
+        <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/domains/posts/PostsHeader/index.tsx
+++ b/src/components/domains/posts/PostsHeader/index.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
-import { Button } from '@components/atoms';
+// import { Button } from '@components/atoms';
 import { PostsFilter } from '../PostsFilter';
 import classes from './PostsHeader.module.scss';
 
@@ -21,7 +21,7 @@ export const PostsHeader = () => {
           }}
           // element={undefined}
         />
-        <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
+        {/* <Button onClick={() => navigate('/setupStudy')} center="글쓰기" /> */}
       </div>
     </div>
   );

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -1,25 +1,19 @@
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 
 import { PostAPI } from '@api/api';
-import { Button } from '@components/atoms';
 import { NewPostCard } from '@components/common/post/PostCard/PostCard';
 import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
 import { queryKeys } from '@hooks/query';
-// import { useSort } from '@hooks/useSort';
-import { PostsFilter } from '../PostsFilter';
 import classes from './postsSection.module.scss';
-import { NotMatchPage } from 'pages';
 
 export const PostsSection = () => {
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-
   const param = searchParams.get('filter');
 
   const { query, TriggerComponent } = useInfiniteTotalPosts({
     getPage: PostAPI.getPostList,
-    pageSize: 4,
+    pageSize: 5,
     filter: param === 'recent' ? undefined : (param as string),
     queryKey: queryKeys.postsAll,
   });
@@ -29,24 +23,9 @@ export const PostsSection = () => {
   }, [searchParams]);
 
   // 제일처음에 로딩을 할 때
-
   if (query.isLoading) {
     return (
-      <main>
-        <div className={classes.postsFilterWrap}>
-          <PostsFilter
-            // datas={totalPosts}
-            // setDatas={setTotalPosts}
-            options={{
-              recent: '최신순',
-              commentNum: '댓글순',
-              view: '조회순',
-              likeNum: '좋아요순',
-            }}
-            // element={undefined}
-          />
-          <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
-        </div>
+      <section className={classes.postsSectionContainer}>
         <ul className={classes.postsSection}>
           {Array(8)
             .fill(0)
@@ -54,42 +33,25 @@ export const PostsSection = () => {
               <NewPostCard key={index} />
             ))}
         </ul>
-        <div style={{ height: '200px' }} />
-      </main>
+        <div className={classes.postsTriggerWrap} />
+      </section>
     );
   }
 
   if (query.status === 'success' && query.data.pages.length) {
     return (
-      <main>
-        <div className={classes.postsFilterWrap}>
-          <PostsFilter
-            // datas={totalPosts}
-            // setDatas={setTotalPosts}
-            options={{
-              recent: '최신순',
-              commentNum: '댓글순',
-              view: '조회순',
-              likeNum: '좋아요순',
-            }}
-            // element={undefined}
-          />
-          <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
-        </div>
-        <section>
-          <div>
-            <ul className={classes.postsSection}>
-              {query.data.pages
-                .flatMap((page) => page.postData.content)
-                .map((post) => (
-                  <NewPostCard key={post.postId} post={post} />
-                ))}
-            </ul>
-          </div>
-          <div style={{ height: '200px' }} />
+      <section className={classes.postsSectionContainer}>
+        <ul className={classes.postsSection}>
+          {query.data.pages
+            .flatMap((page) => page.postData.content)
+            .map((post) => (
+              <NewPostCard key={post.postId} post={post} />
+            ))}
+        </ul>
+        <div className={classes.postsTriggerWrap}>
           <TriggerComponent />
-        </section>
-      </main>
+        </div>
+      </section>
     );
   }
 
@@ -102,7 +64,7 @@ export const PostsSection = () => {
           <h2>일치하는 게시물없음</h2>
         </ul>
       </div>
-      <div style={{ height: '200px' }} />
+      <div className={classes.postsTriggerWrap}></div>
     </main>
   );
 };

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react';
+
+import { PostAPI } from '@api/api';
+import { NewPostCard } from '@components/common/post/PostCard/PostCard';
+import { queryKeys } from '@hooks/query';
+import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
+import { PostsFilter, useSort } from '../PostsFilter';
+import classes from './postsSection.module.scss';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { Button } from '@components/atoms';
+
+export const PostsSection = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { query, TriggerComponent } = useInfiniteTotalPosts({
+    getPage: PostAPI.getPostList,
+    pageSize: 4,
+    queryKey: queryKeys.postsAll,
+  });
+
+  // 1차원 배열을 넣어준다.
+  const {
+    sortedDatas: totalPosts,
+    setSortedDatas: setTotalPosts,
+    setSortFunctions,
+    sortFunctions,
+  } = useSort(query.data?.pages.flatMap((page) => page.postData.content));
+
+  useEffect(() => {
+    const params = searchParams.get('filter');
+    if (query.status === 'success' && query.data && params) {
+      setSortFunctions[params]();
+    }
+  }, [query.status, query.data, searchParams]);
+
+  if (query.status === 'success' && totalPosts && totalPosts.length) {
+    return (
+      <main>
+        <div className={classes.postsFilterWrap}>
+          <PostsFilter
+            datas={totalPosts}
+            setDatas={setTotalPosts}
+            options={{
+              recent: '최신순',
+              comment: '댓글순',
+              view: '조회순',
+              like: '좋아요순',
+            }}
+            element={undefined}
+          />
+          <Button onClick={() => navigate('/createStudy')} center="글쓰기" />
+        </div>
+        <section>
+          <div>
+            <ul className={classes.postsSection}>
+              {totalPosts.map((post) => (
+                <NewPostCard key={post.postId} post={post} />
+              ))}
+            </ul>
+          </div>
+          <div style={{ height: '200px' }} />
+          <TriggerComponent />
+        </section>
+      </main>
+    );
+  }
+
+  // 보여줄 데이터들이 없는 상태
+  return null;
+};

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -6,61 +6,83 @@ import { Button } from '@components/atoms';
 import { NewPostCard } from '@components/common/post/PostCard/PostCard';
 import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
 import { queryKeys } from '@hooks/query';
-import { useSort } from '@hooks/useSort';
+// import { useSort } from '@hooks/useSort';
 import { PostsFilter } from '../PostsFilter';
 import classes from './postsSection.module.scss';
 
 export const PostsSection = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const param = searchParams.get('filter');
+
   const { query, TriggerComponent } = useInfiniteTotalPosts({
     getPage: PostAPI.getPostList,
     pageSize: 4,
+    filter: param === 'recent' ? undefined : (param as string),
     queryKey: queryKeys.postsAll,
   });
 
-  // 1차원 배열을 넣어준다.
-  const {
-    sortedDatas: totalPosts,
-    setSortedDatas: setTotalPosts,
-    setSortFunctions,
-  } = useSort(query.data?.pages.flatMap((page) => page.postData.content));
-
   useEffect(() => {
-    setSearchParams({ filter: 'recent' });
-  }, []);
+    if (!param) setSearchParams({ filter: 'recent' });
+  }, [searchParams]);
 
-  useEffect(() => {
-    const params = searchParams.get('filter');
+  // 제일처음에 로딩을 할 때
 
-    if (query.status === 'success' && query.data && params) {
-      setSortFunctions[params]();
-    }
-  }, [query.status, query.data, searchParams]);
-
-  if (query.status === 'success' && totalPosts && totalPosts.length) {
+  if (query.isLoading) {
     return (
       <main>
         <div className={classes.postsFilterWrap}>
           <PostsFilter
-            datas={totalPosts}
-            setDatas={setTotalPosts}
+            // datas={totalPosts}
+            // setDatas={setTotalPosts}
             options={{
               recent: '최신순',
-              comment: '댓글순',
+              commentNum: '댓글순',
               view: '조회순',
-              like: '좋아요순',
+              likeNum: '좋아요순',
             }}
-            element={undefined}
+            // element={undefined}
+          />
+          <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
+        </div>
+        <ul className={classes.postsSection}>
+          {Array(8)
+            .fill(0)
+            .map((ele, index) => (
+              <NewPostCard key={index} />
+            ))}
+        </ul>
+        <div style={{ height: '200px' }} />
+      </main>
+    );
+  }
+
+  if (query.status === 'success' && query.data.pages.length) {
+    return (
+      <main>
+        <div className={classes.postsFilterWrap}>
+          <PostsFilter
+            // datas={totalPosts}
+            // setDatas={setTotalPosts}
+            options={{
+              recent: '최신순',
+              commentNum: '댓글순',
+              view: '조회순',
+              likeNum: '좋아요순',
+            }}
+            // element={undefined}
           />
           <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
         </div>
         <section>
           <div>
             <ul className={classes.postsSection}>
-              {totalPosts.map((post) => (
-                <NewPostCard key={post.postId} post={post} />
-              ))}
+              {query.data.pages
+                .flatMap((page) => page.postData.content)
+                .map((post) => (
+                  <NewPostCard key={post.postId} post={post} />
+                ))}
             </ul>
           </div>
           <div style={{ height: '200px' }} />

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -9,6 +9,7 @@ import { queryKeys } from '@hooks/query';
 // import { useSort } from '@hooks/useSort';
 import { PostsFilter } from '../PostsFilter';
 import classes from './postsSection.module.scss';
+import { NotMatchPage } from 'pages';
 
 export const PostsSection = () => {
   const navigate = useNavigate();
@@ -92,6 +93,16 @@ export const PostsSection = () => {
     );
   }
 
-  // 보여줄 데이터들이 없는 상태
-  return null;
+  //
+  // 🟠Todo: 보여줄 데이터들이 없거나 잘못된 정렬 카테고리가 선택된 경우 적절한 안내페이지르 보여줘야한다.
+  return (
+    <main>
+      <div>
+        <ul className={classes.postsSection}>
+          <h2>일치하는 게시물없음</h2>
+        </ul>
+      </div>
+      <div style={{ height: '200px' }} />
+    </main>
+  );
 };

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -27,7 +27,12 @@ export const PostsSection = () => {
   } = useSort(query.data?.pages.flatMap((page) => page.postData.content));
 
   useEffect(() => {
+    setSearchParams({ filter: 'recent' });
+  }, []);
+
+  useEffect(() => {
     const params = searchParams.get('filter');
+
     if (query.status === 'success' && query.data && params) {
       setSortFunctions[params]();
     }

--- a/src/components/domains/posts/PostsSection/index.tsx
+++ b/src/components/domains/posts/PostsSection/index.tsx
@@ -1,13 +1,14 @@
 import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { PostAPI } from '@api/api';
-import { NewPostCard } from '@components/common/post/PostCard/PostCard';
-import { queryKeys } from '@hooks/query';
-import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
-import { PostsFilter, useSort } from '../PostsFilter';
-import classes from './postsSection.module.scss';
-import { useNavigate, useSearchParams } from 'react-router-dom';
 import { Button } from '@components/atoms';
+import { NewPostCard } from '@components/common/post/PostCard/PostCard';
+import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
+import { queryKeys } from '@hooks/query';
+import { useSort } from '@hooks/useSort';
+import { PostsFilter } from '../PostsFilter';
+import classes from './postsSection.module.scss';
 
 export const PostsSection = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -23,7 +24,6 @@ export const PostsSection = () => {
     sortedDatas: totalPosts,
     setSortedDatas: setTotalPosts,
     setSortFunctions,
-    sortFunctions,
   } = useSort(query.data?.pages.flatMap((page) => page.postData.content));
 
   useEffect(() => {
@@ -53,7 +53,7 @@ export const PostsSection = () => {
             }}
             element={undefined}
           />
-          <Button onClick={() => navigate('/createStudy')} center="글쓰기" />
+          <Button onClick={() => navigate('/setupStudy')} center="글쓰기" />
         </div>
         <section>
           <div>

--- a/src/components/domains/posts/PostsSection/postsSection.module.scss
+++ b/src/components/domains/posts/PostsSection/postsSection.module.scss
@@ -1,0 +1,14 @@
+.postsSection {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 20px;
+}
+
+.postsFilterWrap {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  height: 100px;
+  gap: 10px;
+}

--- a/src/components/domains/posts/PostsSection/postsSection.module.scss
+++ b/src/components/domains/posts/PostsSection/postsSection.module.scss
@@ -1,14 +1,15 @@
-.postsSection {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 20px;
-}
+.postsSectionContainer {
+  padding: 0 8%;
 
-.postsFilterWrap {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  height: 100px;
-  gap: 10px;
+  .postsSection {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    padding: 0 20px;
+    gap: 20px;
+  }
+
+  .postsTriggerWrap {
+    padding: 10vh 0;
+  }
 }

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -1,6 +1,7 @@
 export const queryKeys = {
   user: ['user'],
-  postsAll: ['postAll'],
+  postsAll: ['postsAll'],
+  postsSlider: ['postsSlider'],
   post: (postId: number) => ['post', postId],
   applicant: (postId: number) => ['applicant', postId],
   searchTitle: (postTitle: string) => ['search', postTitle],

--- a/src/hooks/query/useInfiniteQueryCarousel.tsx
+++ b/src/hooks/query/useInfiniteQueryCarousel.tsx
@@ -8,6 +8,7 @@ interface Props {
   responseKeys: string[];
 }
 
+// Todo: useInfiniteQuerywithScroll, useInfiniteTotalPosts와 합쳐져야함
 export const useInfiniteQueryTest = ({
   getData,
   queryKey,

--- a/src/hooks/query/useInfiniteTotalPosts.tsx
+++ b/src/hooks/query/useInfiniteTotalPosts.tsx
@@ -8,12 +8,14 @@ import { useIntersectionObserver } from './useIntersectionObserver';
 export type FetchPageFuntionType = (
   pageParam: number,
   pageSize: number,
+  filter?: string,
 ) => Promise<AxiosResponse<IResponseOfPage>>;
 
 interface Props {
   getPage: FetchPageFuntionType;
   queryKey: string[];
   pageSize?: number; // 몇개씩 불러올 것인지
+  filter?: string;
 }
 
 // default 값으로 4개씩 불러온다.
@@ -21,15 +23,18 @@ interface Props {
 
 export const useInfiniteTotalPosts = ({
   getPage,
-  pageSize = 4,
   queryKey,
+  pageSize = 4,
+  filter,
 }: Props) => {
+  // console.log(filter, 'useInfinite');
   // 초기값 pageParam은 0 서버에서 넘어오는 last값이 false일 경우(마지막이 아닌 경우) + 1 을 해준다.
   // pageParam(페이지의 넘버, ex)3페이지) , pageSize(한 페이지에 담긴 데이터의 갯수)
   const getPageInfo = async ({ pageParam = 0 }) => {
-    const postData = await getPage(pageParam, pageSize).then(
+    const postData = await getPage(pageParam, pageSize, filter).then(
       (response) => response.data.body.data,
     );
+
     const nextPageParam = !postData.last ? pageParam + 1 : undefined;
     return {
       postData,
@@ -44,6 +49,10 @@ export const useInfiniteTotalPosts = ({
     getNextPageParam: (lastPage, pages) => lastPage.nextPageParam,
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    postsQuery.refetch();
+  }, [filter]);
 
   const TriggerComponent = () => {
     const { ref, observer } = useIntersectionObserver(postsQuery.fetchNextPage);

--- a/src/hooks/query/useInfiniteTotalPosts.tsx
+++ b/src/hooks/query/useInfiniteTotalPosts.tsx
@@ -55,7 +55,10 @@ export const useInfiniteTotalPosts = ({
   }, [filter]);
 
   const TriggerComponent = () => {
-    const { ref, observer } = useIntersectionObserver(postsQuery.fetchNextPage);
+    const { ref, observer } = useIntersectionObserver(
+      postsQuery.fetchNextPage,
+      { rootMargin: '0px 0px 20% 0px' },
+    );
 
     useEffect(() => {
       if (!postsQuery.data) return;

--- a/src/hooks/query/useInfiniteTotalPosts.tsx
+++ b/src/hooks/query/useInfiniteTotalPosts.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+import { useInfiniteQuery } from 'react-query';
+import { AxiosResponse } from 'axios';
+
+import { IResponseOfPage } from 'types/api.types';
+import { useIntersectionObserver } from './useIntersectionObserver';
+
+export type FetchPageFuntionType = (
+  pageParam: number,
+  pageSize: number,
+) => Promise<AxiosResponse<IResponseOfPage>>;
+
+interface Props {
+  getPage: FetchPageFuntionType;
+  queryKey: string[];
+  pageSize?: number; // 몇개씩 불러올 것인지
+}
+
+// default 값으로 4개씩 불러온다.
+// 외부에서 pageSize 조절 가능 전체보기에서는 20개씩 가져올 예정
+
+export const useInfiniteTotalPosts = ({
+  getPage,
+  pageSize = 4,
+  queryKey,
+}: Props) => {
+  // 초기값 pageParam은 0 서버에서 넘어오는 last값이 false일 경우(마지막이 아닌 경우) + 1 을 해준다.
+  // pageParam(페이지의 넘버, ex)3페이지) , pageSize(한 페이지에 담긴 데이터의 갯수)
+  const getPageInfo = async ({ pageParam = 0 }) => {
+    const postData = await getPage(pageParam, pageSize).then(
+      (response) => response.data.body.data,
+    );
+    const nextPageParam = !postData.last ? pageParam + 1 : undefined;
+    return {
+      postData,
+      nextPageParam,
+      isLast: postData.last,
+    };
+  };
+
+  const postsQuery = useInfiniteQuery({
+    queryKey,
+    queryFn: getPageInfo,
+    getNextPageParam: (lastPage, pages) => lastPage.nextPageParam,
+    refetchOnWindowFocus: false,
+  });
+
+  const TriggerComponent = () => {
+    const { ref, observer } = useIntersectionObserver(postsQuery.fetchNextPage);
+
+    useEffect(() => {
+      if (!postsQuery.data) return;
+      const lastPageParam = postsQuery.data.pages.length - 1;
+      const isLast = postsQuery.data.pages[lastPageParam].isLast;
+
+      if (isLast) {
+        observer.disconnect();
+      }
+    }, [postsQuery.data?.pages]);
+
+    return <div ref={ref} />;
+  };
+
+  return {
+    query: postsQuery,
+    TriggerComponent: TriggerComponent,
+  };
+};

--- a/src/hooks/query/useIntersectionObserver.ts
+++ b/src/hooks/query/useIntersectionObserver.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+
+export const useIntersectionObserver = (
+  callback: () => void,
+  options?: IntersectionObserverInit,
+) => {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const observerCallback = (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver,
+  ) => {
+    entries.forEach((entrie) => {
+      if (entrie.isIntersecting) callback();
+    });
+  };
+
+  const observer = new IntersectionObserver(observerCallback, options);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [ref.current]);
+
+  return { ref, observer };
+};

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -3,7 +3,6 @@ import { IResponsePostDetail } from 'types/api.types';
 
 type useSortPropsType = IResponsePostDetail[];
 
-// 🟠 Todo: hooks 폴더 내부로 이동시킬 예정
 export const useSort = (posts: useSortPropsType = []) => {
   const [sortedDatas, setSortedDatas] = useState<any[]>(posts);
 
@@ -42,19 +41,23 @@ export const useSort = (posts: useSortPropsType = []) => {
     setSortedDatas(result);
   };
 
-  const sortFunctions = {
+  type sortOptionNameType = 'recent' | 'commentNum' | 'likeNum' | 'view';
+  type ISortFunctions = Record<sortOptionNameType, () => IResponsePostDetail[]>;
+  type ISetSortFunctions = Record<sortOptionNameType, () => void>;
+
+  const sortFunctions: ISortFunctions = {
     recent: sortRecent,
-    comment: sortCommentCount,
-    like: sortLikeCount,
+    commentNum: sortCommentCount,
+    likeNum: sortLikeCount,
     view: sortViewCount,
   };
 
-  const setSortFunctions = {
+  const setSortFunctions: ISetSortFunctions = {
     recent: setSortRecent,
-    comment: setSortCommentCount,
-    like: setSortLikeCount,
+    commentNum: setSortCommentCount,
+    likeNum: setSortLikeCount,
     view: setSortViewCount,
-  } as { [key: string]: () => void };
+  };
 
   return { sortedDatas, setSortedDatas, setSortFunctions, sortFunctions };
 };

--- a/src/hooks/useSort.ts
+++ b/src/hooks/useSort.ts
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { IResponsePostDetail } from 'types/api.types';
+
+type useSortPropsType = IResponsePostDetail[];
+
+// 🟠 Todo: hooks 폴더 내부로 이동시킬 예정
+export const useSort = (posts: useSortPropsType = []) => {
+  const [sortedDatas, setSortedDatas] = useState<any[]>(posts);
+
+  // setSortFunctions
+  const sortRecent = () => {
+    return [...posts].sort(
+      (left, right) =>
+        Number(new Date(right.createdAt)) - Number(new Date(left.createdAt)),
+    );
+  };
+  const sortCommentCount = () => {
+    return [...posts].sort((left, right) => right.commentNum - left.commentNum);
+  };
+  const sortLikeCount = () => {
+    return [...posts].sort((left, right) => right.likeNum - left.likeNum);
+  };
+  const sortViewCount = () => {
+    return [...posts].sort((left, right) => right.view - left.view);
+  };
+
+  // sortFunctions
+  const setSortRecent = () => {
+    const result = sortRecent();
+    setSortedDatas(result);
+  };
+  const setSortCommentCount = () => {
+    const result = sortCommentCount();
+    setSortedDatas(result);
+  };
+  const setSortLikeCount = () => {
+    const result = sortLikeCount();
+    setSortedDatas(result);
+  };
+  const setSortViewCount = () => {
+    const result = sortViewCount();
+    setSortedDatas(result);
+  };
+
+  const sortFunctions = {
+    recent: sortRecent,
+    comment: sortCommentCount,
+    like: sortLikeCount,
+    view: sortViewCount,
+  };
+
+  const setSortFunctions = {
+    recent: setSortRecent,
+    comment: setSortCommentCount,
+    like: setSortLikeCount,
+    view: setSortViewCount,
+  } as { [key: string]: () => void };
+
+  return { sortedDatas, setSortedDatas, setSortFunctions, sortFunctions };
+};

--- a/src/pages/MainPage/MainPage.scss
+++ b/src/pages/MainPage/MainPage.scss
@@ -8,7 +8,4 @@
     width: 1420px;
     margin: 0 auto;
   }
-  .search {
-    padding: 30px 0 65px 0;
-  }
 }

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,4 +1,4 @@
-import { Search, StudySection } from '@components/common';
+import { SearchSection, StudySection } from '@components/common';
 import BottomBanner from '@components/common/main/Banner/BottomBanner';
 import { MentoSection, MentorReviewSection } from '@components/common';
 import LetterBanner from '@components/common/main/Banner/LetterBanner';
@@ -7,23 +7,13 @@ import './MainPage.scss';
 const MainPage = () => {
   return (
     <div className="mainPage_section_wrapper">
-      <section className="hero">{/* <Categories /> */}</section>
-      <section className="search">
-        <Search />
-      </section>
-      {/* <section className="post body_section">
-        <PostList />
-      </section> */}
+      {/* <section className="hero"><Categories /></section> */}
+      <SearchSection />
       <section className="study_section">
         <StudySection />
       </section>
       <section className="mento_recommend body_section">
-        {/* <button onClick={() => setIsOpenMentorPostViewModal(true)}>모달</button> */}
         <MentoSection type="recommend" />
-        {/* <MentorPostViewModal
-          isOpen={isOpenMentorPostViewModal}
-          setIsOpen={setIsOpenMentorPostViewModal}
-        /> */}
       </section>
       <MentorReviewSection />
       <section className="best_mento body_section">

--- a/src/pages/PostsPage/PostsPage.scss
+++ b/src/pages/PostsPage/PostsPage.scss
@@ -1,0 +1,5 @@
+.body_section {
+  max-width: 1450px;
+  width: 80%;
+  margin: 0 auto;
+}

--- a/src/pages/PostsPage/PostsPage.scss
+++ b/src/pages/PostsPage/PostsPage.scss
@@ -1,5 +1,6 @@
 .body_section {
   max-width: 1450px;
-  width: 80%;
+  padding: 0 30px;
+  width: 85%;
   margin: 0 auto;
 }

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -1,3 +1,4 @@
+import { SearchSection } from '@components/common';
 import { PostsFooter } from '@components/domains/posts/PostsFooter';
 import { PostsHeader } from '@components/domains/posts/PostsHeader';
 import { PostsSection } from '@components/domains/posts/PostsSection';
@@ -5,11 +6,14 @@ import './PostsPage.scss';
 
 const PostsPage = () => {
   return (
-    <main>
-      <PostsHeader />
-      <PostsSection />
-      <PostsFooter />
-    </main>
+    <div>
+      <SearchSection />
+      <main>
+        <PostsHeader />
+        <PostsSection />
+        <PostsFooter />
+      </main>
+    </div>
   );
 };
 

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -1,27 +1,10 @@
-import { PostAPI } from '@api/api';
-import { NewPostCard } from '@components/common/post/PostCard/PostCard';
-import { queryKeys } from '@hooks/query';
-import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
-import { IResponsePostDetail } from 'types/api.types';
+import { PostsSection } from '@components/domains/posts/PostsSection';
+import './PostsPage.scss';
 
 const PostsPage = () => {
-  const { query, TriggerComponent } = useInfiniteTotalPosts({
-    getPage: PostAPI.getPostList,
-    pageSize: 2,
-    queryKey: queryKeys.postsAll,
-  });
-
-  const pages = query.data?.pages;
   return (
-    <div>
-      <div>
-        {pages?.map((page) =>
-          page.postData.content.map((post: IResponsePostDetail) => (
-            <NewPostCard key={post.postId} post={post} />
-          )),
-        )}
-      </div>
-      <TriggerComponent />
+    <div className="body_section">
+      <PostsSection />
     </div>
   );
 };

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -1,0 +1,28 @@
+import { PostAPI } from '@api/api';
+import { NewPostCard } from '@components/common/post/PostCard/PostCard';
+import { queryKeys } from '@hooks/query';
+import { useInfiniteTotalPosts } from '@hooks/query/useInfiniteTotalPosts';
+import { IResponsePostDetail } from 'types/api.types';
+
+const PostsPage = () => {
+  const { query, TriggerComponent } = useInfiniteTotalPosts({
+    getPage: PostAPI.getPostList,
+    pageSize: 2,
+    queryKey: queryKeys.postsAll,
+  });
+
+  const pages = query.data?.pages;
+  return (
+    <div>
+      <div>
+        {pages?.map((page) =>
+          page.postData.content.map((post: IResponsePostDetail) => (
+            <NewPostCard key={post.postId} post={post} />
+          )),
+        )}
+      </div>
+      <TriggerComponent />
+    </div>
+  );
+};
+export default PostsPage;

--- a/src/pages/PostsPage/index.tsx
+++ b/src/pages/PostsPage/index.tsx
@@ -1,11 +1,16 @@
+import { PostsFooter } from '@components/domains/posts/PostsFooter';
+import { PostsHeader } from '@components/domains/posts/PostsHeader';
 import { PostsSection } from '@components/domains/posts/PostsSection';
 import './PostsPage.scss';
 
 const PostsPage = () => {
   return (
-    <div className="body_section">
+    <main>
+      <PostsHeader />
       <PostsSection />
-    </div>
+      <PostsFooter />
+    </main>
   );
 };
+
 export default PostsPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,10 +5,12 @@ import DetailPage from './DetailPage';
 import MyPage from './MyPage';
 import NotMatchPage from './NotMatchPage';
 import EditStudyPage from './EditStudyPage';
+import PostsPage from './PostsPage';
 
 export {
   MainPage,
   NewDetailPage,
+  PostsPage,
   CreateStudyPage,
   DetailPage,
   MyPage,

--- a/src/types/sort.types.ts
+++ b/src/types/sort.types.ts
@@ -1,0 +1,2 @@
+export type sortOptionNameType = 'recent' | 'commentNum' | 'likeNum' | 'view';
+export type ISortOptions = Record<sortOptionNameType, string>;


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용
- 스터디 페이지 전체보기 기능을 `intersection observer`를 이용한 무한스크롤로 구현하였습니다.
- 최초 데이터를 받아올 시 스터디카드 스켈레톤UI를 렌더링합니다.
- 정렬되어진 새로운 게시물들을 서버로부터 받아오는 과정
  1. 정렬 버튼을 클릭했을 시 url의 `sort` Param을 정렬 버튼에 따라 변경합니다.
  2. useEffect를 이용하여 `sort` Param이 변경되면 해당 infiniteQuery 전체 page를 `refetch` 합니다.
  3. 변경된 `sort` param을 적용하여 API를 재호출합니다.
  4. refetch가 완료된 query.data를 통해 게시물을 리렌더링합니다.

- ~정렬되지 않은 페이지(스터디 게시물들)을 받아와 클라이언트에서 정렬~


<br>

## 💻 변경 내용
- Add: useSort: 정렬 기능 관련 로직을 분리
- Add: PostsFilter: 정렬 버튼들이 담겨있는 컴포넌트
- Add: PostsSection: Query Hooks를 호출하고 useSort를 통해 직접적으로 렌더링을 담당하는 컴포넌트
- Add: position: sticky로 동작하는 정렬버튼 리스트바


<br>

## ✅ 관심 리뷰
- [src/components/domains/posts/PostsSection/index.tsx](
https://github.com/Totee-Side-Project/totee-fe/pull/127/files#diff-ab7c6a021f1bcc49c646f1f8b267b2e52b8ba87aebd3f43eda48102280e5567b)
- [src/components/domains/posts/PostsFilter/index.tsx](https://github.com/Totee-Side-Project/totee-fe/pull/127/files#diff-03428779356e94d4a4430011683fa71e25d9e0b8b58e718a567e2e22490b03fa)
