### PR TITLE
Feat: 멘토링 글 상세보기 모달 구현

### DIFF
--- a/src/components/common/mentoring/MentoringPostDetailModal/index.module.scss
+++ b/src/components/common/mentoring/MentoringPostDetailModal/index.module.scss
@@ -1,0 +1,144 @@
+.overlay {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: rgba($color: #000000, $alpha: 0.5);
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal {
+  width: 600px;
+  box-sizing: border-box;
+  background-color: #ffffff;
+  position: absolute;
+  border-radius: 15px;
+  padding: 20px 60px;
+  overflow: hidden;
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: #5f5f5f;
+    }
+
+    .close_icon {
+      width: 25px;
+      height: 25px;
+      color: #667080;
+      cursor: pointer;
+    }
+  }
+
+  .body {
+    margin: 32px 0;
+
+    h1 {
+      font-size: 20px;
+      font-weight: 500;
+      color: #568a35;
+      font-weight: 500;
+    }
+
+    .profile {
+      display: flex;
+      align-items: center;
+      margin-top: 15px;
+
+      img {
+        width: 28px;
+        height: 28px;
+        border-radius: 50%;
+        border: 1px solid #ffffff;
+        box-sizing: border-box;
+        box-shadow: 0px 2px 3px rgba($color: #000000, $alpha: 0.15);
+      }
+
+      .profile_name {
+        display: inline-block;
+        margin-left: 10px;
+      }
+
+      .mentor_badge {
+        margin-left: 8px;
+        text-align: center;
+        width: 30px;
+        height: 12px;
+        background-color: #ff6b00;
+        color: #ffffff;
+        border-radius: 5px;
+        font-size: 8px;
+        font-weight: 500;
+      }
+    }
+
+    .profile_details {
+      margin-top: 8px;
+    }
+
+    .profile_detail {
+      font-size: 14px;
+      color: #858a8d;
+      line-height: 24px;
+
+      & > * + * {
+        margin-left: 8px;
+      }
+    }
+  }
+
+  .cost {
+    color: #323232;
+    font-size: 14px;
+    margin-top: 10px;
+    font-weight: 500;
+  }
+
+  .divider {
+    width: 100%;
+    height: 1px;
+    background-color: #d8d8d8;
+    margin: 25px 0;
+  }
+
+  .content {
+    height: 300px;
+    overflow: auto;
+    color: #222222;
+    font-weight: 350;
+    line-height: 24px;
+    margin-bottom: 80px;
+  }
+
+  .bottom_fixed {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    box-shadow: 0px -4px 10px rgba(0, 0, 0, 0.1);
+    padding: 12px 0;
+    background-color: #ffffff;
+
+    button {
+      width: 150px;
+      height: 40px;
+      background-color: #568a35;
+      font-size: 18px;
+      font-weight: 700;
+      color: #ffffff;
+      border-radius: 10px;
+    }
+  }
+}

--- a/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
+++ b/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
@@ -4,29 +4,30 @@ import { MouseEventHandler } from 'react';
 import { IMentoring } from 'types/api.types';
 
 interface MentoringPostDetailModalProps {
-  isOpen: boolean;
-  onCloseClick: MouseEventHandler;
-  onApplyClick: MouseEventHandler;
+  onCloseClick(): void;
+  onApplyClick(): void;
   mentoring: IMentoring;
 }
 
 function MentoringPostDetailModal({
-  isOpen,
   mentoring,
   onCloseClick,
   onApplyClick,
 }: MentoringPostDetailModalProps) {
-  if (!isOpen) {
-    return null;
-  }
-
   const { title, content, cost, career, profileImageUrl, nickname, field } =
     mentoring;
 
   const formattedCost = Intl.NumberFormat('ko-KR').format(cost);
 
+  const onOverlayClick: MouseEventHandler = (e) => {
+    if (e.target === e.currentTarget) {
+      e.stopPropagation();
+      onCloseClick();
+    }
+  };
+
   return (
-    <div className={classes.overlay}>
+    <div className={classes.overlay} onClick={onOverlayClick}>
       <div className={classes.modal}>
         <div className={classes.header}>
           <h2>멘토링 소개</h2>

--- a/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
+++ b/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
@@ -1,0 +1,52 @@
+import classes from './index.module.scss';
+import { ReactComponent as XIcon } from '@assets/svg/xicon.svg';
+
+const data = {
+  title: '[3년차 개발자 출신] 개발자 취업 관련 상담',
+  mentor: {
+    name: '고인물',
+  },
+  content: `LLLLLLLLLLorem ipsum dolor sit amet consectetur adipisicing elit. Provident recusandae consectetur, odio excepturi nostrum fugit? Culpa eaque esse animi id magnam. Suscipit dolorum voluptate facilis? Ipsam laborum quis voluptas porro!
+    `,
+};
+
+function MentoringPostDetailModal() {
+  return (
+    <div className={classes.overlay}>
+      <div className={classes.modal}>
+        <div className={classes.header}>
+          <h2>멘토링 소개</h2>
+          <XIcon className={classes.close_icon} />
+        </div>
+
+        <div className={classes.body}>
+          <h1>{data.title}</h1>
+          <div className={classes.profile}>
+            <img src="" alt="" />
+            <span className={classes.profile_name}>{data.mentor.name}</span>
+            <div className={classes.mentor_badge}>Totee</div>
+          </div>
+          <div className={classes.profile_details}>
+            <div className={classes.profile_detail}>
+              <span>직무</span>
+              <span>SW 엔지니어</span>
+            </div>
+            <div className={classes.profile_detail}>
+              <span>경력</span>
+              <span>미들 (3-4년차)</span>
+            </div>
+          </div>
+          <div className={classes.cost}>1회 멘토링 1시간 / 11,000원</div>
+          <div className={classes.divider} />
+          <div className={classes.content}>{data.content}</div>
+        </div>
+
+        <div className={classes.bottom_fixed}>
+          <button>신청하기</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MentoringPostDetailModal;

--- a/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
+++ b/src/components/common/mentoring/MentoringPostDetailModal/index.tsx
@@ -1,48 +1,64 @@
 import classes from './index.module.scss';
 import { ReactComponent as XIcon } from '@assets/svg/xicon.svg';
+import { MouseEventHandler } from 'react';
+import { IMentoring } from 'types/api.types';
 
-const data = {
-  title: '[3년차 개발자 출신] 개발자 취업 관련 상담',
-  mentor: {
-    name: '고인물',
-  },
-  content: `LLLLLLLLLLorem ipsum dolor sit amet consectetur adipisicing elit. Provident recusandae consectetur, odio excepturi nostrum fugit? Culpa eaque esse animi id magnam. Suscipit dolorum voluptate facilis? Ipsam laborum quis voluptas porro!
-    `,
-};
+interface MentoringPostDetailModalProps {
+  isOpen: boolean;
+  onCloseClick: MouseEventHandler;
+  onApplyClick: MouseEventHandler;
+  mentoring: IMentoring;
+}
 
-function MentoringPostDetailModal() {
+function MentoringPostDetailModal({
+  isOpen,
+  mentoring,
+  onCloseClick,
+  onApplyClick,
+}: MentoringPostDetailModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  const { title, content, cost, career, profileImageUrl, nickname, field } =
+    mentoring;
+
+  const formattedCost = Intl.NumberFormat('ko-KR').format(cost);
+
   return (
     <div className={classes.overlay}>
       <div className={classes.modal}>
         <div className={classes.header}>
           <h2>멘토링 소개</h2>
-          <XIcon className={classes.close_icon} />
+          <XIcon className={classes.close_icon} onClick={onCloseClick} />
         </div>
 
         <div className={classes.body}>
-          <h1>{data.title}</h1>
+          <h1>{title}</h1>
           <div className={classes.profile}>
-            <img src="" alt="" />
-            <span className={classes.profile_name}>{data.mentor.name}</span>
+            <img src={profileImageUrl} alt={nickname} />
+            <span className={classes.profile_name}>{nickname}</span>
             <div className={classes.mentor_badge}>Totee</div>
           </div>
           <div className={classes.profile_details}>
             <div className={classes.profile_detail}>
               <span>직무</span>
-              <span>SW 엔지니어</span>
+              <span>{field}</span>
             </div>
             <div className={classes.profile_detail}>
               <span>경력</span>
-              <span>미들 (3-4년차)</span>
+              <span>{career}</span>
             </div>
           </div>
-          <div className={classes.cost}>1회 멘토링 1시간 / 11,000원</div>
+          <div className={classes.cost}>
+            1회 멘토링 1시간 / {formattedCost}원
+          </div>
           <div className={classes.divider} />
-          <div className={classes.content}>{data.content}</div>
+          <div className={classes.content}>{content}</div>
         </div>
 
         <div className={classes.bottom_fixed}>
-          <button>신청하기</button>
+          <button onClick={onApplyClick}>신청하기</button>
         </div>
       </div>
     </div>

--- a/src/components/common/section/RecommendMentoringPostsSection/RecommendMentoringPostsSection.tsx
+++ b/src/components/common/section/RecommendMentoringPostsSection/RecommendMentoringPostsSection.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes } from 'react';
+import { HTMLAttributes, useState } from 'react';
 import Slider from 'react-slick';
 import { SectionTitle } from '@components/atoms';
 import RecommendMentorCard from '@components/common/card/RecommendMentoringCard/RecommendMentoringCard';
@@ -6,6 +6,8 @@ import NEXT_ARROW_ICON from '@assets/png/nextarrow.png';
 import PREVIOUS_ARROW_ICON from '@assets/png/prevarrow.png';
 import classes from './RecommendMentoringPostsSection.module.scss';
 import { useGetMentoringList } from '@hooks/query/useGetQuery';
+import { IMentoring } from 'types/api.types';
+import MentoringPostDetailModal from '@components/common/mentoring/MentoringPostDetailModal';
 
 const SECTION_TEXTS = {
   subtitle: 'Level Up Mentoring',
@@ -48,6 +50,9 @@ function SliderNavigateIcon({
 }
 
 function RecommendMentoringPostsSection() {
+  const [currentModalMentoringPost, setCurrentModalMentoringPost] =
+    useState<IMentoring | null>(null);
+
   const { data, isLoading, isError } = useGetMentoringList({
     page: 0,
     size: 20,
@@ -71,32 +76,52 @@ function RecommendMentoringPostsSection() {
     return <></>;
   }
 
+  const handleCloseClick = () => {
+    setCurrentModalMentoringPost(null);
+  };
+
+  const getRecommendMentorCardHandler = (mentoring: IMentoring) => {
+    return () => {
+      setCurrentModalMentoringPost(mentoring);
+    };
+  };
+
   return (
-    <section className={classes.recommend_container}>
-      <div className={classes.title_container}>
-        <SectionTitle
-          title={SECTION_TEXTS.title}
-          sub={SECTION_TEXTS.subtitle}
-          description={SECTION_TEXTS.description}
+    <>
+      {currentModalMentoringPost !== null ? (
+        <MentoringPostDetailModal
+          mentoring={currentModalMentoringPost}
+          onCloseClick={handleCloseClick}
+          onApplyClick={() => {}}
         />
-      </div>
-      <div className={classes.slider_container}>
-        <Slider
-          infinite
-          speed={SLIDER_OPTIONS.speed}
-          slidesToShow={SLIDER_OPTIONS.slidesToShow}
-          prevArrow={<SliderNavigateIcon navigateTo="previous" />}
-          nextArrow={<SliderNavigateIcon navigateTo="next" />}
-        >
-          {data?.data.body.data.content.map((mentoring) => (
-            <RecommendMentorCard
-              key={mentoring.mentoringId}
-              mentoring={mentoring}
-            />
-          ))}
-        </Slider>
-      </div>
-    </section>
+      ) : null}
+      <section className={classes.recommend_container}>
+        <div className={classes.title_container}>
+          <SectionTitle
+            title={SECTION_TEXTS.title}
+            sub={SECTION_TEXTS.subtitle}
+            description={SECTION_TEXTS.description}
+          />
+        </div>
+        <div className={classes.slider_container}>
+          <Slider
+            infinite
+            speed={SLIDER_OPTIONS.speed}
+            slidesToShow={SLIDER_OPTIONS.slidesToShow}
+            prevArrow={<SliderNavigateIcon navigateTo="previous" />}
+            nextArrow={<SliderNavigateIcon navigateTo="next" />}
+          >
+            {data?.data.body.data.content.map((mentoring) => (
+              <RecommendMentorCard
+                key={mentoring.mentoringId}
+                mentoring={mentoring}
+                onClick={getRecommendMentorCardHandler(mentoring)}
+              />
+            ))}
+          </Slider>
+        </div>
+      </section>
+    </>
   );
 }
 

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -4,7 +4,6 @@ import { MentoSection, MentorReviewSection } from '@components/common';
 import LetterBanner from '@components/common/main/Banner/LetterBanner';
 import './MainPage.scss';
 import RecommendMentoringPostsSection from '@components/common/section/RecommendMentoringPostsSection/RecommendMentoringPostsSection';
-import MentoringPostDetailModal from '@components/common/mentoring/MentoringPostDetailModal';
 
 const MainPage = () => {
   return (
@@ -27,7 +26,6 @@ const MainPage = () => {
       <section>
         <BottomBanner />
       </section>
-      <MentoringPostDetailModal />
     </div>
   );
 };

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -4,6 +4,7 @@ import { MentoSection, MentorReviewSection } from '@components/common';
 import LetterBanner from '@components/common/main/Banner/LetterBanner';
 import './MainPage.scss';
 import RecommendMentoringPostsSection from '@components/common/section/RecommendMentoringPostsSection/RecommendMentoringPostsSection';
+import MentoringPostDetailModal from '@components/common/mentoring/MentoringPostDetailModal';
 
 const MainPage = () => {
   return (
@@ -26,6 +27,7 @@ const MainPage = () => {
       <section>
         <BottomBanner />
       </section>
+      <MentoringPostDetailModal />
     </div>
   );
 };


### PR DESCRIPTION
## Description

## 📌 전반적인 개발 내용

- 멘토링 글 상세보기 모달을 구현했습니다.
- #140 

<br>

## 💻 변경 내용

- 멘토링 글 상세보기의 기존 Mock 컴포넌트를 대체할 컴포넌트를 개발했습니다. (UI 모달 컴포넌트)
- 메인페이지의 추천 멘토링의 카드 클릭 시 모달이 열리도록 구현했습니다.
- (신청하기 버튼은 구현되어있지 않습니다)

<br>

## ✅ 관심 리뷰

- 별도 리뷰 포인트는 없습니다!