### PR TITLE
[Fix] 마이페이지 모달 UI 및 데이터 새로고침 렌더링 문제

### DIFF
--- a/src/components/domains/myPage/common/DetailedMemberModal/index.module.scss
+++ b/src/components/domains/myPage/common/DetailedMemberModal/index.module.scss
@@ -77,7 +77,7 @@
     margin: 21px auto;
     padding: 30px 20px;
     word-wrap: break-word;
-    height: 250px;
+    height: 150px;
     overflow: auto;
   }
 
@@ -90,13 +90,12 @@
     line-height: 24px;
     width: 40%;
     height: 50px;
-    margin-top: 30px;
   }
 
   .applicantConfirmationButton {
     display: flex;
     justify-content: space-around;
-    margin-top: 30px;
+    margin-top: 20px;
 
     .acceptButton {
       background-color: #568A35;

--- a/src/hooks/query/index.ts
+++ b/src/hooks/query/index.ts
@@ -29,7 +29,7 @@ export const queryKeys = {
   myStudyPost: ['myStudyPost'],
   participatingStudyPost: ['participatingStudyPost'],
   postLikeList: ['postLikeList'],
-  studyMembers: (postId?: number) => ['studyMembers', postId],
+  studyMembers: (postId: number) => ['studyMembers', postId],
   myMentoringPosts: ['myMentoringPosts'],
   mentoringMembers: (mentoringId?: number) => ['mentoringMembers', mentoringId],
   // 구현 전

--- a/src/hooks/query/useGetQuery.tsx
+++ b/src/hooks/query/useGetQuery.tsx
@@ -148,11 +148,11 @@ export function useGetAlarm() {
   });
 }
 
-export function useGetApplicant(postId: number, options?: any) {
+export function useGetApplicant(postId: number) {
   return useQuery<IMemberType[]>(
     queryKeys.applicant(postId),
     () => ApplicationAPI.getApplicant(postId),
-    { ...options },
+    { enabled: !!postId },
   );
 }
 
@@ -177,11 +177,11 @@ export function useGetPostLikeList() {
   return useQuery<IStudyPostsType>(queryKeys.postLikeList, LikeAPI.LikeList);
 }
 
-export function useGetStudyMembers(postId: number, options?: any) {
+export function useGetStudyMembers(postId: number) {
   return useQuery<IMemberType[]>(
     queryKeys.studyMembers(postId),
     () => TeamAPI.getTeam(postId),
-    { ...options },
+    { enabled: !!postId },
   );
 }
 
@@ -189,10 +189,10 @@ export function useGetMyMentoringPosts() {
   return useQuery(queryKeys.myMentoringPosts, MentoringAPI.getMyMentoringPosts);
 }
 
-export function useGetMentoringMembers(mentoringId: number, options?: any) {
+export function useGetMentoringMembers(mentoringId: number) {
   return useQuery(
     queryKeys.mentoringMembers(mentoringId),
     () => TeamAPI.getMentoringTeam(mentoringId),
-    { ...options },
+    { enabled: !!mentoringId },
   );
 }

--- a/src/hooks/useGetUserActivity.ts
+++ b/src/hooks/useGetUserActivity.ts
@@ -1,29 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { UseQueryResult } from 'react-query';
 
 export const useGetUserActivity = <T, U>(
   useGetPosts: () => UseQueryResult<T, unknown>,
-  useGetMembers: (
-    postId: number,
-    options?: { enabled: boolean },
-  ) => UseQueryResult<U, unknown>,
+  useGetMembers: (postId: number) => UseQueryResult<U, unknown>,
 ) => {
-  const { data: posts } = useGetPosts();
-  const [currentPostId, setCurrentPostId] = useState(-1);
-  const { data: members, refetch: getMembers } = useGetMembers(currentPostId, {
-    enabled: false,
-  });
-
-  useEffect(() => {
-    if (currentPostId !== -1) {
-      getMembers();
-    }
-  }, [currentPostId]);
+  const [currentPostId, setCurrentPostId] = useState(0);
 
   return {
     currentPostId,
     setCurrentPostId,
-    posts,
-    members,
+    posts: useGetPosts().data,
+    members: useGetMembers(currentPostId).data,
   };
 };


### PR DESCRIPTION
## Description

문제1. 마이페이지 모달 UI에서 내용 height를 수정하였습니다.
문제2. 멤버 추방 및 지원 후, 새로고침 없이 최신 데이터를 자동으로 불러오도록 수정했습니다.

## 📌 전반적인 개발 내용
문제2.

추방 및 지원하기 기능은  useMutation의 onSuccess 옵션에서  `queryClient.invalidateQueries` 를 사용하여 서버 요청 성공 후, 최신 데이터를 불러오도록 설정되어 있었습니다.
```
  export const useResignateTeam = (postId: number, nickname: string) => {
  const queryClient = useQueryClient();
  return useMutation(() => TeamAPI.resignateTeam(postId, nickname), {
    onSuccess: () => {
      queryClient.invalidateQueries(queryKeys.studyMembers(postId));
    },
  });
};
```
하지만, 스터디 멤버를 가져오는 useGetStudyMembers의 enabled 옵션이 false로 설정되어 있어서, queryClient.invalidateQueries를 통해 최신 데이터를 불러올 수 없었습니다.
```
export function useGetStudyMembers(postId: number) {
  return useQuery<IMemberType[]>(
    queryKeys.studyMembers(postId),
    () => TeamAPI.getTeam(postId),
    { enabled: false },
  );
}
```
따라서, postId가 존재하지 않을 때만, enabled: false로 설정하였습니다. 
```
export function useGetStudyMembers(postId: number) {
  return useQuery<IMemberType[]>(
    queryKeys.studyMembers(postId),
    () => TeamAPI.getTeam(postId),
    { enabled: !!postId },
  );
}
```

<br>

